### PR TITLE
Update README.md to update intelliJEngineVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ In the module in which the plugin is applied, you need to add code:
 kover {
     isEnabled = true                        // false to disable instrumentation of all test tasks in all modules
     coverageEngine.set(kotlinx.kover.api.CoverageEngine.INTELLIJ) // change instrumentation agent and reporter
-    intellijEngineVersion.set("1.0.637")    // change version of IntelliJ agent and reporter
+    intellijEngineVersion.set("1.0.639")    // change version of IntelliJ agent and reporter
     jacocoEngineVersion.set("0.8.7")        // change version of JaCoCo agent and reporter
     generateReportOnCheck.set(true)         // false to do not execute `koverReport` task before `check` task
 }

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ kover {
 kover {
     enabled = true                          // false to disable instrumentation of all test tasks in all modules
     coverageEngine.set(kotlinx.kover.api.CoverageEngine.INTELLIJ) // change instrumentation agent and reporter
-    intellijEngineVersion.set('1.0.637')    // change version of IntelliJ agent and reporter
+    intellijEngineVersion.set('1.0.639')    // change version of IntelliJ agent and reporter
     jacocoEngineVersion.set('0.8.7')        // change version of JaCoCo agent and reporter
     generateReportOnCheck.set(true)         // false to do not execute `koverReport` task before `check` task
 }


### PR DESCRIPTION
Simply by following the README caused this compilation error below, so I just made a tiny fix here.

```
* What went wrong:
Execution failed for task ':shared:testDebugUnitTest'.
> IntelliJ engine version 1.0.637 is too low, minimal version is 1.0.639
```

The error occurred in 
- skeleton sample KMM application project made by KMM plugin
- Android Studio Bumblebee | 2021.1.1 Beta 5

I made the value same as https://github.com/Kotlin/kotlinx-kover/blob/bedeb7a8785665d649560add625d67d81e55f60d/src/main/kotlin/kotlinx/kover/engines/intellij/Versions.kt#L7