### PR TITLE
Added Gradle minimum version check

### DIFF
--- a/src/main/kotlin/kotlinx/kover/KoverPlugin.kt
+++ b/src/main/kotlin/kotlinx/kover/KoverPlugin.kt
@@ -4,12 +4,24 @@
 
 package kotlinx.kover
 
+import kotlinx.kover.api.KoverVersions.MINIMUM_GRADLE_VERSION
 import kotlinx.kover.appliers.*
+import kotlinx.kover.util.*
 import org.gradle.api.*
+import org.gradle.api.invocation.*
 
 class KoverPlugin : Plugin<Project> {
     override fun apply(target: Project) {
+        target.gradle.checkVersion()
         target.applyToProject()
         target.applyMerged()
+    }
+
+    private fun Gradle.checkVersion() {
+        val current = SemVer.ofVariableOrNull(gradleVersion)!!
+        val min = SemVer.ofVariableOrNull(MINIMUM_GRADLE_VERSION)!!
+        if (current < min) throw GradleException("Gradle version '$gradleVersion' is not supported by Kover Plugin. " +
+                "Minimum supported version is '$MINIMUM_GRADLE_VERSION'")
+
     }
 }

--- a/src/main/kotlin/kotlinx/kover/api/KoverConstants.kt
+++ b/src/main/kotlin/kotlinx/kover/api/KoverConstants.kt
@@ -36,6 +36,8 @@ public object KoverPaths {
 }
 
 public object KoverVersions {
+    public const val MINIMUM_GRADLE_VERSION = "6.8"
+
     internal const val KOVER_TOOL_MINIMAL_VERSION = "1.0.683"
     internal const val KOVER_TOOL_DEFAULT_VERSION = "1.0.683"
     internal const val JACOCO_TOOL_DEFAULT_VERSION = "0.8.8"

--- a/src/main/kotlin/kotlinx/kover/util/Versions.kt
+++ b/src/main/kotlin/kotlinx/kover/util/Versions.kt
@@ -6,6 +6,22 @@ package kotlinx.kover.util
 
 internal class SemVer(val major: Int, val minor: Int, val patch: Int): Comparable<SemVer> {
     companion object {
+        /**
+         * Supported formats:
+         *  - "1" -> 1.0.0
+         *  - "1.2" -> 1.2.0
+         *  - "1.2.3" -> 1.2.3
+         */
+        fun ofVariableOrNull(version: String): SemVer? {
+            val parts = version.substringBefore('-').split(".")
+
+            val major = parts[0].toIntOrNull()?: return null
+            val minor = parts.getOrNull(1)?.toIntOrNull()?: 0
+            val patch = parts.getOrNull(2)?.toIntOrNull()?: 0
+
+            return SemVer(major, minor, patch)
+        }
+
         fun ofThreePartOrNull(version: String): SemVer? {
 
             val parts = version.substringBefore('-').split(".")


### PR DESCRIPTION
At the moment, when trying to use a plugin with a Gradle version less than the minimum, the user receives non-obvious errors.
In order to explicitly tell the user the reason, we need to add a check at the plugin.