### PR TITLE
IDEA-169757 : support charset for html report

### DIFF
--- a/api/kover-gradle-plugin.api
+++ b/api/kover-gradle-plugin.api
@@ -155,10 +155,12 @@ public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverDefaultRepo
 
 public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverHtmlReportConfig {
 	public abstract fun filters (Lorg/gradle/api/Action;)V
+	public abstract fun getCharset ()Ljava/lang/String;
 	public abstract fun getOnCheck ()Z
 	public fun getReportDir ()Ljava/lang/Void;
 	public abstract fun getTitle ()Ljava/lang/String;
 	public fun overrideFilters (Lkotlin/jvm/functions/Function0;)V
+	public abstract fun setCharset (Ljava/lang/String;)V
 	public abstract fun setOnCheck (Z)V
 	public abstract fun setReportDir (Ljava/io/File;)V
 	public abstract fun setReportDir (Lorg/gradle/api/provider/Provider;)V

--- a/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/writer/KoverReportWriter.kt
+++ b/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/writer/KoverReportWriter.kt
@@ -96,6 +96,11 @@ internal class KoverHtmlReportConfigWriter(private val writer: FormattedWriter) 
             writer.assign("title", "\"$value\"")
             field = value
         }
+    override var charset: String? = null
+        set(value) {
+            writer.assign("charset", "\"$value\"")
+            field = value
+        }
 
     override fun setReportDir(dir: File) {
         writer.assign("reportDir", dir.forScript())

--- a/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/ReportsApplier.kt
+++ b/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/ReportsApplier.kt
@@ -35,6 +35,7 @@ internal class ReportsApplier(
 
             reportDir.convention(project.layout.dir(reportConfig.html.reportDirProperty))
             title.convention(reportConfig.html.title ?: project.name)
+            charset.convention(reportConfig.html.charset)
             filters.set((reportConfig.html.filters ?: reportConfig.filters ?: commonFilters).convert())
         }
         if (reportConfig.html.onCheck) {

--- a/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverReportExtension.kt
+++ b/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverReportExtension.kt
@@ -391,7 +391,7 @@ public interface KoverHtmlReportConfig {
     /**
      * Specify charset in HTML reports.
      *
-     * If not specified, Charset.defaultCharset() is used instead.
+     * If not specified, UTF-8 is used instead.
      */
     public var charset: String?
 

--- a/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverReportExtension.kt
+++ b/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverReportExtension.kt
@@ -389,6 +389,13 @@ public interface KoverHtmlReportConfig {
     public var title: String?
 
     /**
+     * Specify charset in HTML reports.
+     *
+     * If not specified, Charset.defaultCharset() is used instead.
+     */
+    public var charset: String?
+
+    /**
      * Generate an HTML report when running the `check` task.
      */
     public var onCheck: Boolean

--- a/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverVersions.kt
+++ b/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverVersions.kt
@@ -15,7 +15,7 @@ public object KoverVersions {
     /**
      * Kover coverage tool version.
      */
-    public const val KOVER_TOOL_VERSION = "1.0.715"
+    public const val KOVER_TOOL_VERSION = "1.0.716"
 
     /**
      * JaCoCo coverage tool version used by default.

--- a/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/internal/KoverReportExtension.kt
+++ b/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/internal/KoverReportExtension.kt
@@ -94,6 +94,8 @@ internal open class KoverHtmlReportConfigImpl @Inject constructor(private val ob
 
     override var title: String? = null
 
+    override var charset: String? = null
+
     internal val reportDirProperty: Property<File> = objects.property()
 
     override fun filters(config: Action<KoverReportFilters>) {

--- a/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/KoverHtmlTask.kt
+++ b/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/KoverHtmlTask.kt
@@ -19,11 +19,14 @@ internal open class KoverHtmlTask @Inject constructor(tool: CoverageTool) : Abst
     @get: Input
     val title: Property<String> = project.objects.property()
 
+    @get: Input
+    val charset: Property<String?> = project.objects.property()
+
     @TaskAction
     fun generate() {
         val htmlDir = reportDir.get().asFile
         htmlDir.mkdirs()
-        tool.htmlReport(htmlDir, title.get(), filters.get(), context())
+        tool.htmlReport(htmlDir, title.get(), charset.get(), filters.get(), context())
     }
 
     fun printPath(): Boolean {

--- a/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/CoverageTool.kt
+++ b/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/CoverageTool.kt
@@ -98,7 +98,7 @@ internal interface CoverageTool {
     /**
      * Generate HTML report.
      */
-    fun htmlReport(htmlDir: File, title: String, filters: ReportFilters, context: ReportContext)
+    fun htmlReport(htmlDir: File, title: String, charset: String?, filters: ReportFilters, context: ReportContext)
 
     /**
      * Perform verification.

--- a/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/jacoco/JacocoHtmlOrXmlReport.kt
+++ b/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/jacoco/JacocoHtmlOrXmlReport.kt
@@ -8,10 +8,16 @@ import kotlinx.kover.gradle.plugin.commons.*
 import java.io.*
 
 
-internal fun ReportContext.jacocoHtmlReport(htmlDir: File, title: String, filters: ReportFilters) {
+internal fun ReportContext.jacocoHtmlReport(htmlDir: File, title: String, charset: String?, filters: ReportFilters) {
     callAntReport(filters, title) {
         htmlDir.mkdirs()
-        invokeMethod("html", mapOf("destdir" to htmlDir))
+
+        val element = if (charset != null) {
+            mapOf("destdir" to htmlDir, "encoding" to charset)
+        } else {
+            mapOf("destdir" to htmlDir)
+        }
+        invokeMethod("html", element)
     }
 }
 

--- a/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/jacoco/JacocoTool.kt
+++ b/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/jacoco/JacocoTool.kt
@@ -40,8 +40,8 @@ internal class JacocoTool(override val variant: CoverageToolVariant) : CoverageT
         context.jacocoXmlReport(xmlFile, filters)
     }
 
-    override fun htmlReport(htmlDir: File, title: String, filters: ReportFilters, context: ReportContext) {
-        context.jacocoHtmlReport(htmlDir, title, filters)
+    override fun htmlReport(htmlDir: File, title: String, charset: String?, filters: ReportFilters, context: ReportContext) {
+        context.jacocoHtmlReport(htmlDir, title, charset, filters)
     }
 
     override fun verify(rules: List<VerificationRule>, commonFilters: ReportFilters, context: ReportContext): List<RuleViolations> {

--- a/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/kover/KoverHtmlOrXmlReport.kt
+++ b/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/kover/KoverHtmlOrXmlReport.kt
@@ -9,9 +9,9 @@ import kotlinx.kover.gradle.plugin.commons.ReportFilters
 import kotlinx.kover.gradle.plugin.util.json.*
 import java.io.*
 
-internal fun ReportContext.koverHtmlReport(htmlDir: File, title: String, filters: ReportFilters) {
+internal fun ReportContext.koverHtmlReport(htmlDir: File, title: String, charset: String?, filters: ReportFilters) {
     val aggGroups = aggregateRawReports(listOf(filters))
-    generateHtmlOrXml(aggGroups.first(), htmlDir = htmlDir, title = title)
+    generateHtmlOrXml(aggGroups.first(), htmlDir = htmlDir, title = title, charset = charset)
 }
 
 internal fun ReportContext.koverXmlReport(xmlFile: File, filters: ReportFilters) {
@@ -24,9 +24,10 @@ private fun ReportContext.generateHtmlOrXml(
     htmlDir: File? = null,
     xmlFile: File? = null,
     title: String? = null,
+    charset: String? = null,
 ) {
     val argsFile = tempDir.resolve("kover-report.json")
-    argsFile.writeHtmlOrXmlJson(files.sources, aggGroup, xmlFile, htmlDir, title)
+    argsFile.writeHtmlOrXmlJson(files.sources, aggGroup, xmlFile, htmlDir, title, charset)
 
     services.exec.javaexec {
         mainClass.set("com.intellij.rt.coverage.report.Main")
@@ -54,7 +55,8 @@ private fun File.writeHtmlOrXmlJson(
     aggregationGroup: AggregationGroup,
     xmlFile: File?,
     htmlDir: File?,
-    title: String?
+    title: String?,
+    charset: String?,
 ) {
     writeJsonObject(mutableMapOf(
         // required fields
@@ -73,6 +75,9 @@ private fun File.writeHtmlOrXmlJson(
         }
         htmlDir?.also { d ->
             it["html"] = d
+        }
+        charset?.also { c ->
+            it["charset"] = c
         }
     })
 }

--- a/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/kover/KoverTool.kt
+++ b/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/kover/KoverTool.kt
@@ -37,8 +37,8 @@ internal class KoverTool(override val variant: CoverageToolVariant) : CoverageTo
         context.koverXmlReport(xmlFile, filters)
     }
 
-    override fun htmlReport(htmlDir: File, title: String, filters: ReportFilters, context: ReportContext) {
-        context.koverHtmlReport(htmlDir, title, filters)
+    override fun htmlReport(htmlDir: File, title: String, charset: String?, filters: ReportFilters, context: ReportContext) {
+        context.koverHtmlReport(htmlDir, title, charset, filters)
     }
 
     override fun verify(


### PR DESCRIPTION
As last step for [IDEA-169757: Code coverage report: html file encoding](https://youtrack.jetbrains.com/issue/IDEA-169757)  and https://github.com/JetBrains/coverage-report/pull/3,  https://github.com/JetBrains/intellij-coverage/pull/57, we need to modify interface to inject charset from configuration.

Reviews will be of great help to resolve issue i'm working on 😄 thanks, bro :)