### PR TITLE
Disabled artifact generation when calling the `assemble` task

### DIFF
--- a/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ArtifactGenerationTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ArtifactGenerationTests.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+package kotlinx.kover.gradle.plugin.test.functional.cases
+
+import kotlinx.kover.gradle.plugin.test.functional.framework.configurator.BuildConfigurator
+import kotlinx.kover.gradle.plugin.test.functional.framework.starter.GeneratedTest
+
+internal class ArtifactGenerationTests {
+
+    @GeneratedTest
+    fun BuildConfigurator.testAssemble() {
+        // generation of Kover artifacts should be disabled on `assemble`
+        // fix of https://github.com/Kotlin/kotlinx-kover/issues/353
+        addProjectWithKover {
+            sourcesFrom("simple")
+        }
+
+        run("assemble") {
+            taskNotCalled("test")
+            taskNotCalled("koverGenerateArtifact")
+        }
+    }
+}

--- a/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/checker/Checker.kt
+++ b/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/checker/Checker.kt
@@ -151,6 +151,11 @@ private class CheckerContextImpl(
         assertEquals(expectedOutcome, outcome, "Unexpected outcome for task '$taskPath'")
     }
 
+    override fun taskNotCalled(taskNameOrPath: String) {
+        val taskPath = taskNameOrPath.asPath()
+        assertNull(result.taskOutcome(taskPath), "Task '$taskNameOrPath' should not have been called")
+    }
+
     override fun taskOutput(taskNameOrPath: String, checker: String.() -> Unit) {
         val taskPath = taskNameOrPath.asPath()
         val taskLog = result.taskLog(taskPath) ?: noTaskFound(taskNameOrPath, taskPath)

--- a/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/checker/CheckerTypes.kt
+++ b/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/checker/CheckerTypes.kt
@@ -34,6 +34,7 @@ internal interface CheckerContext {
     val defaultRawReport: String
     fun checkReports(xmlPath: String, htmlPath: String, mustExist: Boolean)
     fun checkOutcome(taskNameOrPath: String, expectedOutcome: String)
+    fun taskNotCalled(taskNameOrPath: String)
     fun checkDefaultReports(mustExist: Boolean = true)
     fun checkDefaultRawReport(mustExist: Boolean = true)
 }

--- a/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/Artifacts.kt
+++ b/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/Artifacts.kt
@@ -66,6 +66,9 @@ internal fun Project.createArtifactGenerationTask(
     }
 
     val local = configurations.register(localArtifactConfigurationName(variantName)) {
+        // disable generation of Kover artifacts on `assemble`, fix of https://github.com/Kotlin/kotlinx-kover/issues/353
+        isVisible = false
+
         outgoing.artifact(localArtifactFile) {
             asProducer()
             attributes {


### PR DESCRIPTION
Fixes #353

When starting an `assemble` task, all project artifacts marked as visible are generated. Kover artifacts are marked as invisible so that they are created only when generating reports. 
Also, Android projects have several different artifacts that should not be generated all at once