### PR TITLE
Fixed variant level filters for reports

### DIFF
--- a/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ReportsFilteringTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ReportsFilteringTests.kt
@@ -3,6 +3,7 @@
  */
 package kotlinx.kover.gradle.plugin.test.functional.cases
 
+import kotlinx.kover.gradle.plugin.dsl.AggregationType
 import kotlinx.kover.gradle.plugin.test.functional.framework.checker.defaultXmlReport
 import kotlinx.kover.gradle.plugin.test.functional.framework.configurator.*
 import kotlinx.kover.gradle.plugin.test.functional.framework.starter.*
@@ -10,7 +11,7 @@ import kotlinx.kover.gradle.plugin.test.functional.framework.starter.*
 internal class ReportsFilteringTests {
 
     @SlicedGeneratedTest(allLanguages = true, allTools = true)
-    fun BuildConfigurator.testExclude() {
+    fun BuildConfigurator.testXmlCommonExclude() {
         addProjectWithKover {
             sourcesFrom("simple")
 
@@ -20,9 +21,103 @@ internal class ReportsFilteringTests {
                         classes("org.jetbrains.*Exa?ple*")
                     }
                 }
+
+                defaults {
+                    verify {
+                        rule {
+                            // without ExampleClass covered lines count = 2, but 4 with it
+                            maxBound(2, aggregation = AggregationType.COVERED_COUNT)
+                        }
+                    }
+                }
             }
         }
-        run("koverXmlReport") {
+        run("koverXmlReport", "koverVerify") {
+            xml(defaultXmlReport()) {
+                classCounter("org.jetbrains.ExampleClass").assertAbsent()
+                classCounter("org.jetbrains.SecondClass").assertCovered()
+            }
+        }
+    }
+
+    @SlicedGeneratedTest(allLanguages = true, allTools = true)
+    fun BuildConfigurator.testXmlDefaultsExclude() {
+        addProjectWithKover {
+            sourcesFrom("simple")
+
+            koverReport {
+                filters {
+                    excludes {
+                        classes("org.*")
+                    }
+                }
+
+                defaults {
+                    filters {
+                        excludes {
+                            classes("org.jetbrains.*Exa?ple*")
+                        }
+                    }
+
+                    verify {
+                        rule {
+                            // without ExampleClass covered lines count = 2, but 4 with it
+                            maxBound(2, aggregation = AggregationType.COVERED_COUNT)
+                        }
+                    }
+                }
+            }
+        }
+        run("koverXmlReport", "koverVerify") {
+            xml(defaultXmlReport()) {
+                classCounter("org.jetbrains.ExampleClass").assertAbsent()
+                classCounter("org.jetbrains.SecondClass").assertCovered()
+            }
+        }
+    }
+
+    @SlicedGeneratedTest(allLanguages = true, allTools = true)
+    fun BuildConfigurator.testXmlExclude() {
+        addProjectWithKover {
+            sourcesFrom("simple")
+
+            koverReport {
+                filters {
+                    excludes {
+                        classes("foo.*")
+                    }
+                }
+
+                defaults {
+                    filters {
+                        excludes {
+                            classes("org.*")
+                        }
+                    }
+
+                    xml {
+                        filters {
+                            excludes {
+                                classes("org.jetbrains.*Exa?ple*")
+                            }
+                        }
+                    }
+
+                    verify {
+                        filters {
+                            excludes {
+                                classes("org.jetbrains.*Exa?ple*")
+                            }
+                        }
+                        rule {
+                            // without ExampleClass covered lines count = 2, but 4 with it
+                            maxBound(2, aggregation = AggregationType.COVERED_COUNT)
+                        }
+                    }
+                }
+            }
+        }
+        run("koverXmlReport", "koverVerify") {
             xml(defaultXmlReport()) {
                 classCounter("org.jetbrains.ExampleClass").assertAbsent()
                 classCounter("org.jetbrains.SecondClass").assertCovered()

--- a/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/VerificationTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/VerificationTests.kt
@@ -121,26 +121,28 @@ Rule 'missed packages' violated:
 """)
 
                 assertJaCoCoResult("""Rule violated: lines covered count is 41, but expected maximum is 3
-Rule violated: lines covered percentage is 46.00, but expected minimum is 58.00
+Rule violated: lines covered percentage is 46.5900, but expected minimum is 58.0000
 Rule violated: branches covered count for class 'org.jetbrains.kover.test.functional.verification.FullyCovered' is 0, but expected minimum is 1000
-Rule violated: instructions missed percentage for class 'org.jetbrains.kover.test.functional.verification.FullyCovered' is 0, but expected minimum is 100
+Rule violated: instructions missed percentage for class 'org.jetbrains.kover.test.functional.verification.FullyCovered' is 0.0000, but expected minimum is 100.0000
 Rule violated: branches covered count for class 'org.jetbrains.kover.test.functional.verification.PartiallyCoveredFirst' is 2, but expected minimum is 1000
-Rule violated: instructions missed percentage for class 'org.jetbrains.kover.test.functional.verification.PartiallyCoveredFirst' is 0, but expected minimum is 100
+Rule violated: instructions missed percentage for class 'org.jetbrains.kover.test.functional.verification.PartiallyCoveredFirst' is 43.3300, but expected minimum is 100.0000
 Rule violated: branches covered count for class 'org.jetbrains.kover.test.functional.verification.PartiallyCoveredSecond' is 1, but expected minimum is 1000
-Rule violated: instructions missed percentage for class 'org.jetbrains.kover.test.functional.verification.PartiallyCoveredSecond' is 0, but expected minimum is 100
+Rule violated: instructions missed percentage for class 'org.jetbrains.kover.test.functional.verification.PartiallyCoveredSecond' is 51.5600, but expected minimum is 100.0000
 Rule violated: branches covered count for class 'org.jetbrains.kover.test.functional.verification.Uncovered' is 0, but expected minimum is 1000
 Rule violated: branches covered count for class 'org.jetbrains.kover.test.functional.verification.subpackage.SubFullyCovered' is 0, but expected minimum is 1000
-Rule violated: instructions missed percentage for class 'org.jetbrains.kover.test.functional.verification.subpackage.SubFullyCovered' is 0, but expected minimum is 100
+Rule violated: instructions missed percentage for class 'org.jetbrains.kover.test.functional.verification.subpackage.SubFullyCovered' is 0.0000, but expected minimum is 100.0000
 Rule violated: branches covered count for class 'org.jetbrains.kover.test.functional.verification.subpackage.SubPartiallyCoveredFirst' is 0, but expected minimum is 1000
-Rule violated: instructions missed percentage for class 'org.jetbrains.kover.test.functional.verification.subpackage.SubPartiallyCoveredFirst' is 0, but expected minimum is 100
+Rule violated: instructions missed percentage for class 'org.jetbrains.kover.test.functional.verification.subpackage.SubPartiallyCoveredFirst' is 52.3800, but expected minimum is 100.0000
 Rule violated: branches covered count for class 'org.jetbrains.kover.test.functional.verification.subpackage.SubPartiallyCoveredSecond' is 1, but expected minimum is 1000
-Rule violated: instructions missed percentage for class 'org.jetbrains.kover.test.functional.verification.subpackage.SubPartiallyCoveredSecond' is 0, but expected minimum is 100
+Rule violated: instructions missed percentage for class 'org.jetbrains.kover.test.functional.verification.subpackage.SubPartiallyCoveredSecond' is 65.3800, but expected minimum is 100.0000
 Rule violated: branches covered count for class 'org.jetbrains.kover.test.functional.verification.subpackage.SubUncovered' is 0, but expected minimum is 1000
-Rule violated: instructions covered percentage for package 'org.jetbrains.kover.test.functional.verification.subpackage' is 0, but expected minimum is 100
+Rule violated: instructions covered percentage for package 'org.jetbrains.kover.test.functional.verification.subpackage' is 43.6200, but expected minimum is 100.0000
 Rule violated: lines missed count for package 'org.jetbrains.kover.test.functional.verification.subpackage' is 24, but expected maximum is 1
-Rule violated: instructions covered percentage for package 'org.jetbrains.kover.test.functional.verification' is 0, but expected minimum is 100
+Rule violated: instructions covered percentage for package 'org.jetbrains.kover.test.functional.verification' is 48.8500, but expected minimum is 100.0000
 Rule violated: lines missed count for package 'org.jetbrains.kover.test.functional.verification' is 23, but expected maximum is 1
 """)
+
+
             }
         }
     }

--- a/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/ReportsApplier.kt
+++ b/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/ReportsApplier.kt
@@ -35,7 +35,7 @@ internal class ReportsApplier(
 
             reportDir.convention(project.layout.dir(reportConfig.html.reportDirProperty))
             title.convention(reportConfig.html.title ?: project.name)
-            filters.set((reportConfig.html.filters ?: commonFilters).convert())
+            filters.set((reportConfig.html.filters ?: reportConfig.filters ?: commonFilters).convert())
         }
         if (reportConfig.html.onCheck) {
             runOnCheck += htmlTask
@@ -43,7 +43,7 @@ internal class ReportsApplier(
 
         val xmlTask = project.tasks.createReportTask<KoverXmlTask>(xmlReportTaskName(variant.name)) {
             reportFile.convention(project.layout.file(reportConfig.xml.reportFileProperty))
-            filters.set((reportConfig.xml.filters ?: commonFilters).convert())
+            filters.set((reportConfig.xml.filters ?: reportConfig.filters ?: commonFilters).convert())
         }
         if (reportConfig.xml.onCheck) {
             runOnCheck += xmlTask
@@ -55,7 +55,7 @@ internal class ReportsApplier(
 
             // path can't be changed
             resultFile.convention(project.layout.buildDirectory.file(verificationErrorsPath(variant.name)))
-            filters.set((reportConfig.verify.filters ?: commonFilters).convert())
+            filters.set((reportConfig.verify.filters ?: reportConfig.filters ?: commonFilters).convert())
             rules.addAll(converted)
 
             shouldRunAfter(htmlTask)

--- a/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/jacoco/Verification.kt
+++ b/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/jacoco/Verification.kt
@@ -51,14 +51,14 @@ internal fun ReportContext.jacocoVerify(
 
                             AggregationType.COVERED_PERCENTAGE -> {
                                 limitArgs["value"] = "COVEREDRATIO"
-                                min = min?.divide(ONE_HUNDRED)
-                                max = max?.divide(ONE_HUNDRED)
+                                min = min?.divide(ONE_HUNDRED)?.setScale(4)
+                                max = max?.divide(ONE_HUNDRED)?.setScale(4)
                             }
 
                             AggregationType.MISSED_PERCENTAGE -> {
                                 limitArgs["value"] = "MISSEDRATIO"
-                                min = min?.divide(ONE_HUNDRED)
-                                max = max?.divide(ONE_HUNDRED)
+                                min = min?.divide(ONE_HUNDRED)?.setScale(4)
+                                max = max?.divide(ONE_HUNDRED)?.setScale(4)
                             }
                         }
 


### PR DESCRIPTION
Fixes #366

The report mistakenly took into account only filters inside the report and common filters for all variants, in fact, the overriding order should be: common filters for all variants > filters per variant > filters for a specific report in the variant