### PR TITLE
Fix broken migration link in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 0.7.0 / 2023-05-16
 ===================
 This release introduce API rework in order to support configuration cache, project isolation model, Android Gradle plugin.
-It is incompatible with the previous version, and we provide best-effort migration assistance as well as [migration guide](https://github.com/Kotlin/kotlinx-kover/blob/v0.7.0/docs/migration-to-0.7.0.md)
+It is incompatible with the previous version, and we provide best-effort migration assistance as well as [migration guide](https://github.com/Kotlin/kotlinx-kover/blob/v0.7.0/docs/gradle-plugin/migrations/migration-to-0.7.0.md)
 
 ### Features
 


### PR DESCRIPTION
### How to reproduce?
- click migration guid at `CHANGELOG.md`

### AS-IS (broken)
> Also same as `main` branch

<img width="1464" alt="image" src="https://github.com/Kotlin/kotlinx-kover/assets/34061042/4d60cc0d-a578-4aaf-93e4-d5c4262de7db">

### TO-BE (fixed)
<img width="1009" alt="image" src="https://github.com/Kotlin/kotlinx-kover/assets/34061042/8cf0f175-2406-4496-ba57-4eef2b2380c7">



