### PR TITLE
Fixed up-to-date checks for Kover tasks

### DIFF
--- a/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/configurator/ConfiguratorTypes.kt
+++ b/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/configurator/ConfiguratorTypes.kt
@@ -15,6 +15,8 @@ internal interface BuildConfigurator {
 
     fun run(vararg args: String, checker: CheckerContext.() -> Unit = {})
 
+    fun edit(filePath: String, editor: (String) -> String)
+
     fun runWithError(vararg args: String, errorChecker: CheckerContext.() -> Unit = {})
 
     fun useLocalCache(use: Boolean = true)
@@ -59,6 +61,10 @@ internal abstract class BuilderConfiguratorWrapper(private val origin: BuildConf
 
     override fun run(vararg args: String, checker: CheckerContext.() -> Unit) {
         origin.run(*args) { checker() }
+    }
+
+    override fun edit(filePath: String, editor: (String) -> String) {
+        origin.edit(filePath, editor)
     }
 
     override fun runWithError(vararg args: String, errorChecker: CheckerContext.() -> Unit) {

--- a/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/starter/Single.kt
+++ b/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/starter/Single.kt
@@ -4,7 +4,6 @@
 
 package kotlinx.kover.gradle.plugin.test.functional.framework.starter
 
-import kotlinx.kover.api.*
 import kotlinx.kover.gradle.plugin.commons.*
 import kotlinx.kover.gradle.plugin.test.functional.framework.common.*
 import kotlinx.kover.gradle.plugin.test.functional.framework.configurator.*
@@ -74,7 +73,7 @@ private class SingleTestInterceptor : InvocationInterceptor {
         dir.writeBuild(config, slice)
         logInfo("Build was created for slice ($slice) in directory ${dir.uri}")
 
-        dir.runAndCheck(config.runs)
+        dir.runAndCheck(config.steps)
         // clear directory if where are no errors
         logInfo("Build successfully for slice ($slice), deleting the directory ${dir.uri}")
         dir.deleteRecursively()

--- a/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/starter/Sliced.kt
+++ b/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/starter/Sliced.kt
@@ -67,7 +67,7 @@ private class SlicedTestInterceptor : InvocationInterceptor {
         dir.writeBuild(config, slice)
         logInfo("Build was created for slice ($slice) in directory ${dir.uri}")
 
-        dir.runAndCheck(config.runs)
+        dir.runAndCheck(config.steps)
         // clear directory if where are no errors
         logInfo("Build successfully for slice ($slice), deleting the directory ${dir.uri}")
         dir.deleteRecursively()

--- a/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/AbstractKoverReportTask.kt
+++ b/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/AbstractKoverReportTask.kt
@@ -16,6 +16,7 @@ import org.gradle.api.tasks.*
 import org.gradle.configurationcache.extensions.*
 import org.gradle.kotlin.dsl.*
 import org.gradle.process.*
+import java.io.File
 
 
 internal abstract class AbstractKoverReportTask(@Internal protected val tool: CoverageTool) : DefaultTask() {
@@ -30,6 +31,22 @@ internal abstract class AbstractKoverReportTask(@Internal protected val tool: Co
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
     val reportClasspath: ConfigurableFileCollection = project.objects.fileCollection()
+
+    /**
+     * This will cause the task to be considered out-of-date when source files have changed.
+     */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    internal val sources: Collection<File>
+        get() = collectAllFiles().sources
+
+    /**
+     * This will cause the task to be considered out-of-date when binary reports have changed.
+     */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    internal val reports: Collection<File>
+        get() = collectAllFiles().reports
 
     @get:Nested
     val toolVariant: CoverageToolVariant = tool.variant


### PR DESCRIPTION
In order to carry out up-to-date checks correctly, it is necessary to add the source directories and binary reports to Kover tasks inputs

Fixes #371