### PR TITLE
Fixed issues with cache miss of build cache at the time of relocation

### DIFF
--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/AccessorsTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/AccessorsTests.kt
@@ -38,7 +38,7 @@ internal class AccessorsTests {
                 }
             """.trimIndent()
             )
-        }.generate("Test accessors", "custom")
+        }.generate()
 
         val result = build.runWithParams("custom")
 
@@ -96,7 +96,7 @@ internal class AccessorsTests {
                 }
             """.trimIndent()
             )
-        }.generate("Test names accessors", "custom")
+        }.generate()
 
         val result = build.runWithParams("tasks")
 

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/BuildCacheRelocationTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/BuildCacheRelocationTests.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.kover.gradle.plugin.test.functional.cases
+
+import kotlinx.kover.gradle.plugin.test.functional.framework.runner.buildFromTemplate
+import kotlinx.kover.gradle.plugin.test.functional.framework.runner.runWithParams
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import kotlin.test.assertEquals
+
+class BuildCacheRelocationTests {
+    @Test
+    fun testDefaultTasks() {
+        val cachePath = Files.createTempDirectory("test-gradle-cache-").toFile().canonicalPath
+
+        val cachePatch = """
+            buildCache {
+                local {
+                    directory = "$cachePath"
+                }
+            }"""
+
+        val buildSource = buildFromTemplate("counters")
+
+        val gradleBuild1 = buildSource.generate()
+        gradleBuild1.targetDir.resolve("settings.gradle.kts").appendText(cachePatch)
+        val result1 = gradleBuild1.runWithParams("koverXmlReport", "koverHtmlReport", "koverVerify", "--build-cache")
+        assertEquals("SUCCESS", result1.taskOutcome(":test"))
+        assertEquals("SUCCESS", result1.taskOutcome(":koverGenerateArtifact"))
+        assertEquals("SUCCESS", result1.taskOutcome(":koverXmlReport"))
+        assertEquals("SUCCESS", result1.taskOutcome(":koverHtmlReport"))
+        assertEquals("SUCCESS", result1.taskOutcome(":koverVerify"))
+
+        /*
+        since the build is created from a template,
+        repeat generation will create a new directory with exactly the same contents as the previous one.
+
+        Thus, when using the same cache, tasks will not be executed, and the result will be taken from the cache.
+         */
+        val gradleBuild2 = buildSource.generate()
+        gradleBuild2.targetDir.resolve("settings.gradle.kts").appendText(cachePatch)
+        val result2 = gradleBuild2.runWithParams("koverXmlReport", "koverHtmlReport", "koverVerify", "--build-cache")
+        assertEquals("FROM-CACHE", result2.taskOutcome(":test"))
+        assertEquals("FROM-CACHE", result2.taskOutcome(":koverGenerateArtifact"))
+        assertEquals("FROM-CACHE", result2.taskOutcome(":koverXmlReport"))
+        assertEquals("FROM-CACHE", result2.taskOutcome(":koverHtmlReport"))
+        assertEquals("FROM-CACHE", result2.taskOutcome(":koverVerify"))
+    }
+}

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ConfigurationCacheTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ConfigurationCacheTests.kt
@@ -3,7 +3,6 @@
  */
 package kotlinx.kover.gradle.plugin.test.functional.cases
 
-import kotlinx.kover.gradle.plugin.test.functional.framework.common.*
 import kotlinx.kover.gradle.plugin.test.functional.framework.configurator.*
 import kotlinx.kover.gradle.plugin.test.functional.framework.starter.*
 import java.io.*

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ConfigurationOrderTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ConfigurationOrderTests.kt
@@ -45,7 +45,7 @@ internal class ConfigurationOrderTests {
     @Test
     fun testIllegalVariantNameInConfig() {
         val buildSource = buildFromTemplate("android-no-variant-for-config")
-        val build = buildSource.generate("No variant config", "template")
+        val build = buildSource.generate()
         val buildResult = build.runWithParams("clean")
 
         buildResult.checkNoAndroidSdk()
@@ -56,7 +56,7 @@ internal class ConfigurationOrderTests {
     @Test
     fun testIllegalVariantNameInMerge() {
         val buildSource = buildFromTemplate("android-no-variant-for-merge")
-        val build = buildSource.generate("No variant merge", "template")
+        val build = buildSource.generate()
         val buildResult = build.runWithParams("clean")
 
         buildResult.checkNoAndroidSdk()

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/runner/BuildsRunner.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/runner/BuildsRunner.kt
@@ -19,11 +19,15 @@ internal fun createBuildSource(localMavenDir: String, koverVersion: String): Bui
 internal interface BuildSource {
     var overriddenKotlinVersion: String?
 
+    var buildName: String
+
+    var buildType: String
+
     fun copyFrom(rootProjectDir: File)
 
     fun from(rootProjectDir: File)
 
-    fun generate(buildName: String, buildType: String): GradleBuild
+    fun generate(): GradleBuild
 }
 
 internal interface GradleBuild {
@@ -45,6 +49,10 @@ private class BuildSourceImpl(val localMavenDir: String, val koverVersion: Strin
 
     private var copy: Boolean = false
 
+    override var buildName: String = "default"
+
+    override var buildType: String = "default"
+
     override var overriddenKotlinVersion: String? = null
 
     override fun copyFrom(rootProjectDir: File) {
@@ -57,7 +65,7 @@ private class BuildSourceImpl(val localMavenDir: String, val koverVersion: Strin
         copy = false
     }
 
-    override fun generate(buildName: String, buildType: String): GradleBuild {
+    override fun generate(): GradleBuild {
         val actualDir = dir ?: throw Exception("No source was specified for the build")
         val targetDir = if (copy) {
             val tmpDir = Files.createTempDirectory("${buildName.substringAfterLast('/')}-").toFile()

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/runner/CustomizableRunning.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/runner/CustomizableRunning.kt
@@ -25,6 +25,8 @@ internal fun buildFromTemplate(templateName: String): BuildSource {
         throw Exception("Template not found: '$templateName'")
     }
     source.copyFrom(dir)
+    source.buildType = "template"
+    source.buildName = templateName
 
     return source
 }
@@ -48,6 +50,7 @@ internal fun generateBuild(generator: (File) -> Unit): BuildSource {
     generator(dir)
     val source = createBuildSource(localRepositoryPath, koverVersionCurrent)
     source.overriddenKotlinVersion = overriddenKotlinVersion
+    source.buildType = "generated"
     source.from(dir)
 
     return source

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/starter/Example.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/starter/Example.kt
@@ -37,11 +37,12 @@ private class ExampleGradleTest : DirectoryBasedGradleTest() {
 
         val exampleName = annotation.exampleDir
         val buildSource = buildFromExample(exampleName)
+        buildSource.buildType = "example test"
+        buildSource.buildName = exampleName
         val commands = annotation.commands.toList()
-        return RunCommand(exampleName, buildSource, commands)
+        return RunCommand(buildSource, commands)
     }
 
-    override val testType: String = "Example"
 }
 
 

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/starter/Single.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/starter/Single.kt
@@ -72,8 +72,10 @@ private class SingleTestInterceptor : InvocationInterceptor {
             dir.writeBuild(config, slice)
             logInfo("Build was created for slice ($slice) in directory ${dir.uri}")
         }
+        buildSource.buildType = "single generated"
+        buildSource.buildName = slice.toString()
 
-        val build = buildSource.generate(slice.toString(), "single generated")
+        val build = buildSource.generate()
         build.runAndCheck(config.steps)
         // clear directory if where are no errors
         build.clear()

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/starter/Sliced.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/starter/Sliced.kt
@@ -65,7 +65,9 @@ private class SlicedTestInterceptor : InvocationInterceptor {
             dir.writeBuild(config, slice)
             logInfo("Build was created for slice ($slice) in directory ${dir.uri}")
         }
-        val build = buildSource.generate(slice.toString(), "sliced generated")
+        buildSource.buildType = "sliced generated"
+        buildSource.buildName = slice.toString()
+        val build = buildSource.generate()
         build.runAndCheck(config.steps)
         // clear directory if where are no errors
         build.clear()

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/starter/Template.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/starter/Template.kt
@@ -29,9 +29,9 @@ private class TemplateGradleTest : DirectoryBasedGradleTest() {
         val templateName = annotation.templateName
 
         val sources = buildFromTemplate(templateName)
+        sources.buildType = "template test"
+        sources.buildName = templateName
         val commands = annotation.commands.toList()
-        return RunCommand(templateName, sources, commands)
+        return RunCommand(sources, commands)
     }
-
-    override val testType: String = "Template"
 }

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/JvmTestTaskConfigurator.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/JvmTestTaskConfigurator.kt
@@ -59,7 +59,7 @@ private class JvmTestTaskArgumentProvider(
     private val tempDir: File,
     private val toolProvider: Provider<CoverageTool>,
 
-    // relative sensitive for file - this is a comparison by file name and its contents
+    // relative sensitivity for file is a comparison by file name and its contents
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)
     val agentJar: Provider<File>,

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/JvmTestTaskConfigurator.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/JvmTestTaskConfigurator.kt
@@ -59,8 +59,9 @@ private class JvmTestTaskArgumentProvider(
     private val tempDir: File,
     private val toolProvider: Provider<CoverageTool>,
 
+    // relative sensitive for file - this is a comparison by file name and its contents
     @get:InputFile
-    @get:PathSensitive(PathSensitivity.ABSOLUTE)
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     val agentJar: Provider<File>,
 
     @get:Input

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/services/KoverAgentJarTask.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/services/KoverAgentJarTask.kt
@@ -21,7 +21,7 @@ import javax.inject.*
  */
 @CacheableTask
 internal abstract class KoverAgentJarTask : DefaultTask() {
-    // relative sensitive for file collection which are not FileTree  - this is a comparison by file name and its contents
+    // relative sensitivity for file collections which are not FileTree is a comparison by file name and its contents
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val agentClasspath: ConfigurableFileCollection

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/services/KoverAgentJarTask.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/services/KoverAgentJarTask.kt
@@ -21,8 +21,9 @@ import javax.inject.*
  */
 @CacheableTask
 internal abstract class KoverAgentJarTask : DefaultTask() {
+    // relative sensitive for file collection which are not FileTree  - this is a comparison by file name and its contents
     @get:InputFiles
-    @get:PathSensitive(PathSensitivity.ABSOLUTE)
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val agentClasspath: ConfigurableFileCollection
 
     @get:OutputFile


### PR DESCRIPTION
Using `PathSensitivity.ABSOLUTE` in all cases will lead to a cache miss

Fixes #413