### PR TITLE
Updates KDoc for `KoverReportExtension.xml` to be documented as `xml` configuring, not `html`

### DIFF
--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverReportExtension.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverReportExtension.kt
@@ -190,7 +190,7 @@ public interface KoverReportsConfig {
     public fun html(config: Action<KoverHtmlReportConfig>)
 
     /**
-     * Configure HTML report for current report variant.
+     * Configure XML report for current report variant.
      * ```
      *  xml {
      *      filters {


### PR DESCRIPTION
Whilst reading the Kdoc I noticed that the docs for the `KoverReportExtension.xml` was incorrectly documented as configuring `html` reports.


I've opened the PR, but haven't been through every step of the contribution guidelines. I will do it shortly. 