### PR TITLE
Added ability to specify verification rules in the root of reports config

### DIFF
--- a/docs/gradle-plugin/configuring.md
+++ b/docs/gradle-plugin/configuring.md
@@ -17,6 +17,66 @@ See also [verification explanations](#verification)
 
 ```kotlin
 koverReport {
+    // filters for all reports in all variants 
+    filters {
+        excludes {
+            // excludes class by fully-qualified JVM class name, wildcards '*' and '?' are available
+            classes("com.*")
+        }
+    }
+  
+    // verification rules for verification tasks in all variants
+    verify {
+        // add common verification rule
+        rule {
+            // check this rule during verification 
+            isEnabled = true
+  
+            // specify the code unit for which coverage will be aggregated 
+            entity = kotlinx.kover.gradle.plugin.dsl.GroupingEntityType.APPLICATION
+  
+            // overriding filters only for current rule
+            filters {
+              excludes {
+                // excludes class by fully-qualified JVM class name, wildcards '*' and '?' are available
+                classes("com.example.*")
+                // excludes all classes located in specified package and it subpackages, wildcards '*' and '?' are available
+                packages("com.another.subpackage")
+                // excludes all classes and functions, annotated by specified annotations (with BINARY or RUNTIME AnnotationRetention), wildcards '*' and '?' are available
+                annotatedBy("*Generated*")
+              }
+              includes {
+                // includes class by fully-qualified JVM class name, wildcards '*' and '?' are available
+                classes("com.example.*")
+                // includes all classes located in specified package and it subpackages
+                packages("com.another.subpackage")
+              }
+            }
+  
+            // specify verification bound for this rule
+            bound {
+              // lower bound
+              minValue = 1
+  
+              // upper bound
+              maxValue = 99
+  
+              // specify which units to measure coverage for
+              metric = kotlinx.kover.gradle.plugin.dsl.MetricType.LINE
+  
+              // specify an aggregating function to obtain a single value that will be checked against the lower and upper boundaries
+              aggregation = kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
+            }
+  
+            // add lower bound for percentage of covered lines
+            minBound(2)
+  
+            // add upper bound for percentage of covered lines
+            maxBound(98)
+        }
+    }
+    
+    
     // configure default reports - for Kotlin/JVM or Kotlin/MPP projects or merged android variants  
     defaults {
         // filters for all default reports 
@@ -195,6 +255,65 @@ See also [verification explanations](#verification)
 
 ```kotlin
 koverReport {
+    // filters for all reports in all variants 
+    filters {
+        excludes {
+            // excludes class by fully-qualified JVM class name, wildcards '*' and '?' are available
+            classes("com.*")
+        }
+    }
+
+    // verification rules for verification tasks in all variants
+    verify {
+        // add common verification rule
+        rule {
+            // check this rule during verification 
+            isEnabled = true
+
+            // specify the code unit for which coverage will be aggregated 
+            entity = kotlinx.kover.gradle.plugin.dsl.GroupingEntityType.APPLICATION
+
+            // overriding filters only for current rule
+            filters {
+                excludes {
+                    // excludes class by fully-qualified JVM class name, wildcards '*' and '?' are available
+                    classes("com.example.*")
+                    // excludes all classes located in specified package and it subpackages, wildcards '*' and '?' are available
+                    packages("com.another.subpackage")
+                    // excludes all classes and functions, annotated by specified annotations (with BINARY or RUNTIME AnnotationRetention), wildcards '*' and '?' are available
+                    annotatedBy("*Generated*")
+                }
+                includes {
+                    // includes class by fully-qualified JVM class name, wildcards '*' and '?' are available
+                    classes("com.example.*")
+                    // includes all classes located in specified package and it subpackages
+                    packages("com.another.subpackage")
+                }
+            }
+
+            // specify verification bound for this rule
+            bound {
+                // lower bound
+                minValue = 1
+
+                // upper bound
+                maxValue = 99
+
+                // specify which units to measure coverage for
+                metric = kotlinx.kover.gradle.plugin.dsl.MetricType.LINE
+
+                // specify an aggregating function to obtain a single value that will be checked against the lower and upper boundaries
+                aggregation = kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
+            }
+
+            // add lower bound for percentage of covered lines
+            minBound(2)
+
+            // add upper bound for percentage of covered lines
+            maxBound(98)
+        }
+    }
+    
     // configure report for `release` build variant (Build Type + Flavor) - generated by tasks `koverXmlReportRelease`, `koverHtmlReportRelease` etc
     androidReports("release") {
         // filters for all reports of `release` build variant 

--- a/docs/gradle-plugin/index.md
+++ b/docs/gradle-plugin/index.md
@@ -97,7 +97,11 @@ To configure reports, the [default reports settings block](configuring#configuri
 ```kotlin
 koverReport {
     filters {
-        // filters for all reports
+        // filters for all report variants
+    }
+  
+    verify {
+        // verification rules for all report variants
     }
 
     defaults {
@@ -122,6 +126,10 @@ To configure reports, the [android reports settings block](configuring#configuri
 koverReport {
     filters {
         // filters for reports of all build variants
+    }
+
+    verify {
+        // verification rules for all report variants
     }
 
     androidReports("release") {

--- a/docs/gradle-plugin/index.md
+++ b/docs/gradle-plugin/index.md
@@ -97,11 +97,11 @@ To configure reports, the [default reports settings block](configuring#configuri
 ```kotlin
 koverReport {
     filters {
-        // filters for all report variants
+        // filters for all reports
     }
   
     verify {
-        // verification rules for all report variants
+        // verification rules for all reports
     }
 
     defaults {

--- a/kover-gradle-plugin/api/kover-gradle-plugin.api
+++ b/kover-gradle-plugin/api/kover-gradle-plugin.api
@@ -240,6 +240,7 @@ public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverReportExten
 	public abstract fun androidReports (Ljava/lang/String;Lorg/gradle/api/Action;)V
 	public abstract fun defaults (Lorg/gradle/api/Action;)V
 	public abstract fun filters (Lorg/gradle/api/Action;)V
+	public abstract fun verify (Lorg/gradle/api/Action;)V
 }
 
 public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverReportFilter {
@@ -272,6 +273,11 @@ public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverTestsExclus
 	public abstract fun tasks ([Ljava/lang/String;)V
 }
 
+public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverVerificationRulesConfig {
+	public abstract fun rule (Ljava/lang/String;Lorg/gradle/api/Action;)V
+	public abstract fun rule (Lorg/gradle/api/Action;)V
+}
+
 public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverVerifyBound {
 	public abstract fun getAggregation ()Lkotlinx/kover/gradle/plugin/dsl/AggregationType;
 	public fun getCounter ()Lkotlinx/kover/gradle/plugin/dsl/MetricType;
@@ -287,10 +293,8 @@ public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverVerifyBound
 	public fun setValueType (Lkotlinx/kover/gradle/plugin/dsl/AggregationType;)V
 }
 
-public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverVerifyReportConfig {
+public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverVerifyReportConfig : kotlinx/kover/gradle/plugin/dsl/KoverVerificationRulesConfig {
 	public abstract fun getOnCheck ()Z
-	public abstract fun rule (Ljava/lang/String;Lorg/gradle/api/Action;)V
-	public abstract fun rule (Lorg/gradle/api/Action;)V
 	public abstract fun setOnCheck (Z)V
 }
 

--- a/kover-gradle-plugin/examples/jvm/defaults/build.gradle.kts
+++ b/kover-gradle-plugin/examples/jvm/defaults/build.gradle.kts
@@ -32,6 +32,29 @@ koverReport {
         }
     }
 
+    verify {
+        rule {
+            isEnabled = true
+            entity = kotlinx.kover.gradle.plugin.dsl.GroupingEntityType.APPLICATION
+
+            filters {
+                excludes {
+                    classes("com.example.verify.subpackage.*")
+                }
+                includes {
+                    classes("com.example.verify.*")
+                }
+            }
+
+            bound {
+                minValue = 1
+                maxValue = 99
+                metric = kotlinx.kover.gradle.plugin.dsl.MetricType.LINE
+                aggregation = kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
+            }
+        }
+    }
+
     defaults {
         filters {
             excludes {
@@ -73,7 +96,6 @@ koverReport {
         verify {
             onCheck = true
             rule {
-                isEnabled = true
                 entity = kotlinx.kover.gradle.plugin.dsl.GroupingEntityType.APPLICATION
 
                 filters {
@@ -86,8 +108,8 @@ koverReport {
                 }
 
                 bound {
-                    minValue = 1
-                    maxValue = 99
+                    minValue = 2
+                    maxValue = 98
                     metric = kotlinx.kover.gradle.plugin.dsl.MetricType.LINE
                     aggregation = kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
                 }

--- a/kover-gradle-plugin/examples/jvm/merged/build.gradle.kts
+++ b/kover-gradle-plugin/examples/jvm/merged/build.gradle.kts
@@ -25,13 +25,11 @@ koverReport {
         }
     }
 
-    defaults {
-        verify {
-            rule {
-                bound {
-                    minValue = 50
-                    maxValue = 75
-                }
+    verify {
+        rule {
+            bound {
+                minValue = 50
+                maxValue = 75
             }
         }
     }

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ReportAnnotationFilterTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ReportAnnotationFilterTests.kt
@@ -24,15 +24,13 @@ internal class ReportAnnotationFilterTests {
                     }
                 }
 
-                defaults {
-                    verify {
-                        rule {
-                            bound {
-                                metric = LINE
-                                aggregation = AggregationType.COVERED_COUNT
-                                minValue = 9
-                                maxValue = 9
-                            }
+                verify {
+                    rule {
+                        bound {
+                            metric = LINE
+                            aggregation = AggregationType.COVERED_COUNT
+                            minValue = 9
+                            maxValue = 9
                         }
                     }
                 }
@@ -64,27 +62,26 @@ internal class ReportAnnotationFilterTests {
                         annotatedBy("org.jetbrains.Exclude", "*ByMask")
                     }
                 }
+                verify {
+                    rule {
+                        filters {
+                            // clear all filters
+                        }
+
+                        bound {
+                            metric = LINE
+                            aggregation = AggregationType.COVERED_COUNT
+                            minValue = 16
+                            maxValue = 16
+                        }
+                    }
+                }
 
                 defaults {
                     xml {
                         filters {
                             excludes {
                                 annotatedBy("org.jetbrains.OverriddenExclude")
-                            }
-                        }
-                    }
-
-                    verify {
-                        rule {
-                            filters {
-                                // clear all filters
-                            }
-
-                            bound {
-                                metric = LINE
-                                aggregation = AggregationType.COVERED_COUNT
-                                minValue = 16
-                                maxValue = 16
                             }
                         }
                     }

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ReportsFilteringTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ReportsFilteringTests.kt
@@ -21,13 +21,10 @@ internal class ReportsFilteringTests {
                         classes("org.jetbrains.*Exa?ple*")
                     }
                 }
-
-                defaults {
-                    verify {
-                        rule {
-                            // without ExampleClass covered lines count = 2, but 4 with it
-                            maxBound(2, aggregation = AggregationType.COVERED_COUNT)
-                        }
+                verify {
+                    rule {
+                        // without ExampleClass covered lines count = 2, but 4 with it
+                        maxBound(2, aggregation = AggregationType.COVERED_COUNT)
                     }
                 }
             }
@@ -51,18 +48,17 @@ internal class ReportsFilteringTests {
                         classes("org.*")
                     }
                 }
+                verify {
+                    rule {
+                        // without ExampleClass covered lines count = 2, but 4 with it
+                        maxBound(2, aggregation = AggregationType.COVERED_COUNT)
+                    }
+                }
 
                 defaults {
                     filters {
                         excludes {
                             classes("org.jetbrains.*Exa?ple*")
-                        }
-                    }
-
-                    verify {
-                        rule {
-                            // without ExampleClass covered lines count = 2, but 4 with it
-                            maxBound(2, aggregation = AggregationType.COVERED_COUNT)
                         }
                     }
                 }

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/TasksOrderingTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/TasksOrderingTests.kt
@@ -12,11 +12,9 @@ internal class TasksOrderingTests {
         addProjectWithKover {
             sourcesFrom("simple")
             koverReport {
-                defaults {
-                    verify {
-                        rule {
-                            minBound(100)
-                        }
+                verify {
+                    rule {
+                        minBound(100)
                     }
                 }
             }

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/VerificationTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/VerificationTests.kt
@@ -15,18 +15,16 @@ internal class VerificationTests {
             sourcesFrom("simple")
 
             koverReport {
-                defaults {
-                    verify {
-                        rule("test rule") {
-                            bound {
-                                minValue = 50
-                                maxValue = 60
-                            }
-                            bound {
-                                aggregation = AggregationType.COVERED_COUNT
-                                minValue = 2
-                                maxValue = 10
-                            }
+                verify {
+                    rule("test rule") {
+                        bound {
+                            minValue = 50
+                            maxValue = 60
+                        }
+                        bound {
+                            aggregation = AggregationType.COVERED_COUNT
+                            minValue = 2
+                            maxValue = 10
                         }
                     }
                 }
@@ -42,49 +40,47 @@ internal class VerificationTests {
             sourcesFrom("verification")
 
             koverReport {
-                defaults {
-                    verify {
-                        rule("counts rule") {
-                            bound {
-                                minValue = 58
-                                maxValue = 60
-                            }
-                            bound {
-                                aggregation = AggregationType.COVERED_COUNT
-                                minValue = 2
-                                maxValue = 3
-                            }
+                verify {
+                    rule("counts rule") {
+                        bound {
+                            minValue = 58
+                            maxValue = 60
                         }
-                        rule("fully uncovered instructions by classes") {
-                            entity = GroupingEntityType.CLASS
-                            bound {
-                                metric = MetricType.INSTRUCTION
-                                aggregation = AggregationType.MISSED_PERCENTAGE
-                                minValue = 100
-                            }
+                        bound {
+                            aggregation = AggregationType.COVERED_COUNT
+                            minValue = 2
+                            maxValue = 3
                         }
-                        rule("fully covered instructions by packages") {
-                            entity = GroupingEntityType.PACKAGE
-                            bound {
-                                metric = MetricType.INSTRUCTION
-                                aggregation = AggregationType.COVERED_PERCENTAGE
-                                minValue = 100
-                            }
+                    }
+                    rule("fully uncovered instructions by classes") {
+                        entity = GroupingEntityType.CLASS
+                        bound {
+                            metric = MetricType.INSTRUCTION
+                            aggregation = AggregationType.MISSED_PERCENTAGE
+                            minValue = 100
                         }
-                        rule("branches by classes") {
-                            entity = GroupingEntityType.CLASS
-                            bound {
-                                metric = MetricType.BRANCH
-                                aggregation = AggregationType.COVERED_COUNT
-                                minValue = 1000
-                            }
+                    }
+                    rule("fully covered instructions by packages") {
+                        entity = GroupingEntityType.PACKAGE
+                        bound {
+                            metric = MetricType.INSTRUCTION
+                            aggregation = AggregationType.COVERED_PERCENTAGE
+                            minValue = 100
                         }
-                        rule("missed packages") {
-                            entity = GroupingEntityType.PACKAGE
-                            bound {
-                                aggregation = AggregationType.MISSED_COUNT
-                                maxValue = 1
-                            }
+                    }
+                    rule("branches by classes") {
+                        entity = GroupingEntityType.CLASS
+                        bound {
+                            metric = MetricType.BRANCH
+                            aggregation = AggregationType.COVERED_COUNT
+                            minValue = 1000
+                        }
+                    }
+                    rule("missed packages") {
+                        entity = GroupingEntityType.PACKAGE
+                        bound {
+                            aggregation = AggregationType.MISSED_COUNT
+                            maxValue = 1
                         }
                     }
                 }
@@ -141,11 +137,61 @@ Rule violated: lines missed count for package 'org.jetbrains.kover.test.function
 Rule violated: instructions covered percentage for package 'org.jetbrains.kover.test.functional.verification' is *, but expected minimum is 100.0000
 Rule violated: lines missed count for package 'org.jetbrains.kover.test.functional.verification' is 23, but expected maximum is 1
 """)
-
-
             }
         }
     }
 
+    @SlicedGeneratedTest(allLanguages = true, allTools = true)
+    fun BuildConfigurator.testRootRules() {
+        addProjectWithKover {
+            sourcesFrom("simple")
+
+            koverReport {
+                verify {
+                    rule("root rule") {
+                        bound {
+                            minValue = 99
+                        }
+                    }
+                }
+            }
+        }
+
+        run("koverVerify", errorExpected = true) {
+            verification {
+                assertKoverResult("Rule 'root rule' violated: lines covered percentage is *, but expected minimum is 99\n")
+                assertJaCoCoResult("Rule violated: lines covered percentage is *, but expected minimum is 99.0000\n")
+            }
+        }
+    }
+
+    @SlicedGeneratedTest(allLanguages = true, allTools = true)
+    fun BuildConfigurator.testRootRulesOverride() {
+        addProjectWithKover {
+            sourcesFrom("simple")
+
+            koverReport {
+                verify {
+                    rule("root rule") {
+                        bound {
+                            minValue = 99
+                        }
+                    }
+
+                    defaults {
+                        verify {
+                            rule("root rule") {
+                                bound {
+                                    minValue = 10
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        run("koverVerify")
+    }
 
 }

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/writer/KoverReportWriter.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/writer/KoverReportWriter.kt
@@ -15,6 +15,10 @@ internal class KoverReportExtensionWriter(private val writer: FormattedWriter) :
         writer.call("filters", config) { KoverReportFiltersWriter(it) }
     }
 
+    override fun verify(config: Action<KoverVerificationRulesConfig>) {
+        writer.call("verify", config) { KoverVerificationRulesConfigWriter(it) }
+    }
+
     override fun defaults(config: Action<KoverDefaultReportsConfig>) {
         writer.call("defaults", config) { KoverDefaultReportsWriter(it) }
     }
@@ -141,12 +145,18 @@ internal class KoverXmlReportConfigWriter(private val writer: FormattedWriter) :
 
 }
 
-internal class KoverVerifyReportConfigWriter(private val writer: FormattedWriter) : KoverVerifyReportConfig {
+internal class KoverVerifyReportConfigWriter(private val writer: FormattedWriter) :
+    KoverVerificationRulesConfigWriter(writer), KoverVerifyReportConfig {
+
     override var onCheck: Boolean = true
         set(value) {
             writer.assign("onCheck", value.toString())
             field = value
         }
+}
+
+internal open class KoverVerificationRulesConfigWriter(private val writer: FormattedWriter) :
+    KoverVerificationRulesConfig {
 
     override fun rule(config: Action<KoverVerifyRule>) {
         writer.call("rule", config) { KoverVerifyRuleWriter(it) }

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/no-tests-jvm/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/no-tests-jvm/build.gradle.kts
@@ -8,11 +8,9 @@ repositories {
 }
 
 koverReport {
-    defaults {
-        verify {
-            rule {
-                minBound(50)
-            }
+    verify {
+        rule {
+            minBound(50)
         }
     }
 }

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/no-tests-mpp/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/no-tests-mpp/build.gradle.kts
@@ -17,11 +17,9 @@ repositories {
  */
 
 koverReport {
-    defaults {
-        verify {
-            rule {
-                minBound(50)
-            }
+    verify {
+        rule {
+            minBound(50)
         }
     }
 }

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/AppliersCommons.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/AppliersCommons.kt
@@ -27,10 +27,6 @@ internal fun ObjectFactory.defaultReports(layout: ProjectLayout): KoverDefaultRe
         onCheck = false
     }
 
-    reports.verify {
-        onCheck = true
-    }
-
     return reports
 }
 

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/ProjectApplier.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/ProjectApplier.kt
@@ -87,7 +87,7 @@ internal class ProjectApplier(private val project: Project) {
                     val configs =
                         reportExtension.namedReports[kit.buildVariant] ?: project.androidReports(kit.buildVariant)
 
-                    applier.applyConfig(configs, reportExtension.filters)
+                    applier.applyConfig(configs, reportExtension.filters, reportExtension.verify)
                     applier.applyCompilationKit(kit)
 
                     androidAppliers[kit.buildVariant] = applier
@@ -107,7 +107,7 @@ internal class ProjectApplier(private val project: Project) {
                     defaultApplier.mergeWith(applier)
                 }
 
-                defaultApplier.applyConfig(reportExtension.default, reportExtension.filters)
+                defaultApplier.applyConfig(reportExtension.default, reportExtension.filters, reportExtension.verify)
             }
         }
 

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/reports/ReportsVariantApplier.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/reports/ReportsVariantApplier.kt
@@ -17,6 +17,7 @@ import kotlinx.kover.gradle.plugin.commons.artifactConfigurationName
 import kotlinx.kover.gradle.plugin.dsl.AggregationType
 import kotlinx.kover.gradle.plugin.dsl.GroupingEntityType
 import kotlinx.kover.gradle.plugin.dsl.MetricType
+import kotlinx.kover.gradle.plugin.dsl.internal.*
 import kotlinx.kover.gradle.plugin.dsl.internal.KoverReportFiltersImpl
 import kotlinx.kover.gradle.plugin.dsl.internal.KoverReportsConfigImpl
 import kotlinx.kover.gradle.plugin.dsl.internal.KoverVerifyBoundImpl
@@ -112,7 +113,11 @@ internal sealed class ReportsVariantApplier(
     }
 
 
-    fun applyConfig(reportConfig: KoverReportsConfigImpl, commonFilters: KoverReportFiltersImpl? = null) {
+    fun applyConfig(
+        reportConfig: KoverReportsConfigImpl,
+        commonFilters: KoverReportFiltersImpl? = null,
+        commonVerify: KoverVerificationRulesConfigImpl? = null
+    ) {
         val runOnCheck = mutableListOf<TaskProvider<*>>()
 
         htmlTask.configure {
@@ -136,17 +141,18 @@ internal sealed class ReportsVariantApplier(
         }
 
         verifyTask.configure {
-            val converted = reportConfig.verify.rules.map { it.convert() }
+            val resultRules = reportConfig.verify?.rules ?: commonVerify?.rules ?: emptyList()
+            val converted = resultRules.map { it.convert() }
 
             // path can't be changed
             resultFile.convention(project.layout.buildDirectory.file(verificationErrorsPath(variantName)))
-            filters.set((reportConfig.verify.filters ?: reportConfig.filters ?: commonFilters).convert())
+            filters.set((reportConfig.verify?.filters ?: reportConfig.filters ?: commonFilters).convert())
             rules.addAll(converted)
 
             shouldRunAfter(htmlTask)
             shouldRunAfter(xmlTask)
         }
-        if (reportConfig.verify.onCheck) {
+        if (reportConfig.verify?.onCheck == true || (reportConfig.verify == null && variantName == DEFAULT_KOVER_VARIANT_NAME)) {
             runOnCheck += verifyTask
         }
 

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverReportExtension.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverReportExtension.kt
@@ -69,7 +69,7 @@ import java.io.*
  */
 public interface KoverReportExtension {
     /**
-     * Specify common filters for all report variant, these filters will be inherited in HTML/XML/verification reports.
+     * Specify common filters for all report variants, these filters will be inherited in HTML/XML/verification reports.
      * They can be redefined in the settings of a specific report.
      * ```
      *  filters {

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverReportExtension.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverReportExtension.kt
@@ -20,6 +20,9 @@ import java.io.*
  *      filters {
  *          // common filters for all reports of all variants
  *      }
+ *      verify {
+ *          // common verification rules for all variants
+ *      }
  *
  *      // default reports - special reports that are filled in by default with class measurements from Kotlin/JVM or Kotlin/MPP projects
  *      defaults {
@@ -66,7 +69,7 @@ import java.io.*
  */
 public interface KoverReportExtension {
     /**
-     * Specify common filters for the current report variant, these filters will be inherited in HTML/XML/verification reports.
+     * Specify common filters for all report variant, these filters will be inherited in HTML/XML/verification reports.
      * They can be redefined in the settings of a specific report.
      * ```
      *  filters {
@@ -81,6 +84,24 @@ public interface KoverReportExtension {
      * ```
      */
     public fun filters(config: Action<KoverReportFilters>)
+
+
+    /**
+     * Specify common verification rules for all report variants: JVM and Android build variants.
+     * They can be overridden in the settings for a specific report variant or a specific report in a particular variant.
+     * ```
+     *  verify {
+     *      rule {
+     *          // verification rule
+     *      }
+     *
+     *      rule("custom rule name") {
+     *          // named verification rule
+     *      }
+     *  }
+     * ```
+     */
+    public fun verify(config: Action<KoverVerificationRulesConfig>)
 
     /**
      * Configure reports for classes from Kotlin/JVM or Kotlin/MPP projects.
@@ -637,13 +658,31 @@ public interface KoverXmlReportConfig {
  *  }
  * ```
  */
-public interface KoverVerifyReportConfig {
+public interface KoverVerifyReportConfig: KoverVerificationRulesConfig {
     /**
      * Verify coverage when running the `check` task.
      * `null` by default, for Kotlin JVM and Kotlin MPP triggered on `check` task, but not for Android.
      */
     public var onCheck: Boolean
+}
 
+/**
+ * Configuration to specify verification rules.
+ *
+ * Example:
+ * ```
+ *  verify {
+ *      rule {
+ *          // verification rule
+ *      }
+ *
+ *      rule("custom rule name") {
+ *          // named verification rule
+ *      }
+ *  }
+ * ```
+ */
+public interface KoverVerificationRulesConfig {
     /**
      * Add new coverage verification rule to check after test task execution.
      */


### PR DESCRIPTION
Now it is not necessary to specify the same rules in different report variants, it is enough to specify them at the root, and they will be inherited in each variant, if they are not explicitly overridden.