### PR TITLE
Fixed usage Kover Gradle Plugin in buildSrc directory

### DIFF
--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/MetadataCompatibilityTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/MetadataCompatibilityTests.kt
@@ -1,0 +1,12 @@
+package kotlinx.kover.gradle.plugin.test.functional.cases
+
+import kotlinx.kover.gradle.plugin.test.functional.framework.checker.CheckerContext
+import kotlinx.kover.gradle.plugin.test.functional.framework.starter.TemplateTest
+
+internal class MetadataCompatibilityTests {
+
+    @TemplateTest("buildsrc-usage", [":koverXmlReport"])
+    fun CheckerContext.test() {
+        // no-op
+    }
+}

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/common/Environment.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/common/Environment.kt
@@ -32,7 +32,7 @@ internal val overriddenKotlinVersion = System.getProperty("kover.test.kotlin.ver
 /**
  * Custom version of Gradle runner for functional tests.
  */
-internal val overriddenGradleWrapperVersion: String? = System.getProperty("kover.test.gradle.version")
+internal val overriddenGradleVersion: String? = System.getProperty("kover.test.gradle.version")
 
 /**
  * Result path to the Android SDK. `null` if not defined.
@@ -40,6 +40,11 @@ internal val overriddenGradleWrapperVersion: String? = System.getProperty("kover
 internal val androidSdkDir: String? = System.getProperty("kover.test.android.sdk")
 
 
+/**
+ * Version of gradle which functional tests are run by.
+ */
+internal val defaultGradleVersion: String = System.getProperty("gradleVersion")
+    ?: throw Exception("System property 'gradleVersion' not defined for functional tests")
 
 /**
  * Flag to run functional tests within debug agent.

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/runner/BuildsRunner.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/runner/BuildsRunner.kt
@@ -7,7 +7,11 @@ package kotlinx.kover.gradle.plugin.test.functional.framework.runner
 import kotlinx.kover.gradle.plugin.test.functional.framework.common.isDebugEnabled
 import kotlinx.kover.gradle.plugin.test.functional.framework.common.logInfo
 import kotlinx.kover.gradle.plugin.test.functional.framework.common.uri
+import kotlinx.kover.gradle.plugin.test.functional.framework.starter.*
+import kotlinx.kover.gradle.plugin.test.functional.framework.starter.buildSrc
 import kotlinx.kover.gradle.plugin.test.functional.framework.starter.patchSettingsFile
+import kotlinx.kover.gradle.plugin.util.SemVer
+import org.opentest4j.TestAbortedException
 import java.io.File
 import java.nio.file.Files
 
@@ -39,6 +43,7 @@ internal interface GradleBuild {
 }
 
 internal data class BuildEnv(
+    val gradleVersion: SemVer,
     val wrapperDir: File,
     val androidSdkDir: String? = null,
     val disableBuildCacheByDefault: Boolean = true
@@ -75,10 +80,14 @@ private class BuildSourceImpl(val localMavenDir: String, val koverVersion: Strin
             actualDir
         }
 
-        targetDir.patchSettingsFile(
+        targetDir.settings.patchSettingsFile(
             "$buildType '$buildName', project dir: ${targetDir.uri}",
             koverVersion, localMavenDir, overriddenKotlinVersion
         )
+
+        val buildSrcScript = targetDir.buildSrc?.build
+        buildSrcScript?.patchKoverDependency(koverVersion)
+        buildSrcScript?.addLocalRepository(localMavenDir)
 
         return GradleBuildImpl(targetDir, copy, buildName, buildType)
     }
@@ -94,6 +103,18 @@ private class GradleBuildImpl(
     private var runCount = 0
 
     override fun run(args: List<String>, env: BuildEnv): BuildResult {
+        val requirements = targetDir.requirements
+        requirements.minGradle?.let { minVersion ->
+            if (env.gradleVersion < minVersion) {
+                throw TestAbortedException("Used Gradle version '${env.gradleVersion}' lower then minimal required '$minVersion'")
+            }
+        }
+        requirements.maxGradle?.let { maxVersion ->
+            if (env.gradleVersion >= maxVersion) {
+                throw TestAbortedException("Used Gradle version '${env.gradleVersion}' higher or equals then maximal exclusive '$maxVersion'")
+            }
+        }
+
         logInfo("Starting build $buildType '$buildName' with commands '${args.joinToString(" ")}'")
 
         val gradleArgs: MutableList<String> = mutableListOf()

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/runner/BuildsRunner.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/runner/BuildsRunner.kt
@@ -106,12 +106,12 @@ private class GradleBuildImpl(
         val requirements = targetDir.requirements
         requirements.minGradle?.let { minVersion ->
             if (env.gradleVersion < minVersion) {
-                throw TestAbortedException("Used Gradle version '${env.gradleVersion}' lower then minimal required '$minVersion'")
+                throw TestAbortedException("Used Gradle version '${env.gradleVersion}' lower than minimal required '$minVersion'")
             }
         }
         requirements.maxGradle?.let { maxVersion ->
             if (env.gradleVersion >= maxVersion) {
-                throw TestAbortedException("Used Gradle version '${env.gradleVersion}' higher or equals then maximal exclusive '$maxVersion'")
+                throw TestAbortedException("Used Gradle version '${env.gradleVersion}' higher or equals than maximal '$maxVersion'")
             }
         }
 

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/runner/CustomizableRunning.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/runner/CustomizableRunning.kt
@@ -9,10 +9,12 @@ import kotlinx.kover.gradle.plugin.test.functional.framework.common.androidSdkDi
 import kotlinx.kover.gradle.plugin.test.functional.framework.common.koverVersionCurrent
 import kotlinx.kover.gradle.plugin.test.functional.framework.common.defaultGradleWrapperDir
 import kotlinx.kover.gradle.plugin.test.functional.framework.common.examplesDir
-import kotlinx.kover.gradle.plugin.test.functional.framework.common.overriddenGradleWrapperVersion
+import kotlinx.kover.gradle.plugin.test.functional.framework.common.overriddenGradleVersion
 import kotlinx.kover.gradle.plugin.test.functional.framework.common.localRepositoryPath
 import kotlinx.kover.gradle.plugin.test.functional.framework.common.overriddenKotlinVersion
 import kotlinx.kover.gradle.plugin.test.functional.framework.common.templateBuildsDir
+import kotlinx.kover.gradle.plugin.util.SemVer
+import org.gradle.kotlin.dsl.provideDelegate
 import java.io.File
 import java.nio.file.Files
 
@@ -57,20 +59,27 @@ internal fun generateBuild(generator: (File) -> Unit): BuildSource {
 }
 
 
-internal fun GradleBuild.runWithParams(args: List<String>): BuildResult {
-    val wrapperDir =
-        if (overriddenGradleWrapperVersion == null) defaultGradleWrapperDir else getWrapper(overriddenGradleWrapperVersion)
-
-    val buildEnv = BuildEnv(wrapperDir, androidSdkDir)
-
-    return run(args, buildEnv)
-}
 internal fun GradleBuild.runWithParams(vararg args: String): BuildResult {
     return runWithParams(args.toList())
 }
 
-private fun getWrapper(version: String): File {
-    val wrapperDir = gradleWrappersRoot.resolve(version)
-    if (!wrapperDir.exists()) throw Exception("Wrapper for Gradle version '$version' is not supported by functional tests")
+internal fun GradleBuild.runWithParams(args: List<String>): BuildResult {
+    val buildEnv = BuildEnv(gradleVersion, wrapperDir, androidSdkDir)
+
+    return run(args, buildEnv)
+}
+
+private val gradleVersion: SemVer by lazy {
+    val version = overriddenGradleVersion?: defaultGradleVersion
+    SemVer.ofVariableOrNull(version) ?: throw IllegalArgumentException("Can not parse Gradle version '$version'")
+}
+
+
+private val wrapperDir =
+    if (overriddenGradleVersion == null) defaultGradleWrapperDir else getWrapper(overriddenGradleVersion)
+
+private fun getWrapper(gradleVersion: String): File {
+    val wrapperDir = gradleWrappersRoot.resolve(gradleVersion)
+    if (!wrapperDir.exists()) throw Exception("Wrapper for Gradle version '$gradleVersion' is not supported by functional tests")
     return wrapperDir
 }

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/runner/CustomizableRunning.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/runner/CustomizableRunning.kt
@@ -70,7 +70,7 @@ internal fun GradleBuild.runWithParams(args: List<String>): BuildResult {
 }
 
 private val gradleVersion: SemVer by lazy {
-    val version = overriddenGradleVersion?: defaultGradleVersion
+    val version = overriddenGradleVersion ?: defaultGradleVersion
     SemVer.ofVariableOrNull(version) ?: throw IllegalArgumentException("Can not parse Gradle version '$version'")
 }
 

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    kotlin("jvm") version "1.4.20"
+}
+
+apply(plugin = "org.jetbrains.kotlinx.kover")
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.0")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/buildSrc/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/buildSrc/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    kotlin("jvm") version "1.4.20"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlinx:kover-gradle-plugin:TEST")
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/buildSrc/src/main/kotlin/Usage.kt
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/buildSrc/src/main/kotlin/Usage.kt
@@ -1,0 +1,2 @@
+class Class {
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/requires
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/requires
@@ -1,0 +1,1 @@
+MAX_GRADLE=8.0

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/settings.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+rootProject.name = "buildsrc-usage"
+

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/src/main/kotlin/ExampleClass.kt
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/src/main/kotlin/ExampleClass.kt
@@ -1,0 +1,9 @@
+class ExampleClass {
+    fun example() {
+        println("example")
+    }
+
+    fun unused() {
+        println("unused")
+    }
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/src/test/kotlin/TestClass.kt
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/src/test/kotlin/TestClass.kt
@@ -1,0 +1,8 @@
+import org.junit.jupiter.api.Test
+
+class TestClass {
+    @Test
+    fun testBranches() {
+        ExampleClass().example()
+    }
+}

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/reports/ReportsVariantApplier.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/reports/ReportsVariantApplier.kt
@@ -39,7 +39,7 @@ import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 
-internal sealed class ReportsVariantApplier(
+internal abstract class ReportsVariantApplier(
     private val project: Project,
     private val variantName: String,
     private val type: ReportsVariantType,
@@ -58,14 +58,16 @@ internal sealed class ReportsVariantApplier(
 
     init {
         artifactGenTask = project.tasks.register<KoverArtifactGenerationTask>(artifactGenerationTaskName(variantName))
+
+        val artifactProperty = project.layout.buildDirectory.file(artifactFilePath(variantName))
         artifactGenTask.configure {
-            artifactFile.set(project.layout.buildDirectory.file(artifactFilePath(variantName)))
+            artifactFile.set(artifactProperty)
         }
 
         config = project.configurations.register(artifactConfigurationName(variantName)) {
             // disable generation of Kover artifacts on `assemble`, fix of https://github.com/Kotlin/kotlinx-kover/issues/353
             isVisible = false
-            outgoing.artifact(artifactGenTask.map { task -> task.artifactFile }) {
+            outgoing.artifact(artifactProperty) {
                 asProducer()
                 attributes {
                     // common Kover artifact attributes


### PR DESCRIPTION
Fixes #415

`kotlin-dsl` itself specifies the language version to ensure compatibility of the Kotlin DSL API. 
Since we ourselves guarantee and test compatibility with previous Gradle versions, we can override language version.
The easiest way to do this now is to specify the version in the `afterEvaluate` block