### PR TITLE
Implemented the ability to specify flexible patterns for merging reports

### DIFF
--- a/docs/gradle-plugin/configuring.md
+++ b/docs/gradle-plugin/configuring.md
@@ -539,7 +539,7 @@ koverReport {
 ```
 This will add the reports contents of `release` Android build variant to default reports.
 
-Is it acceptable to use wildcards `*` (zero or several arbitrary characters) and `?` (strictly one arbitrary character).
+Is it acceptable to use wildcards `*` (zero or several arbitrary characters) and `?` (exactly one arbitrary character).
 The pattern is case-insensitive: `release` and `RelEase` processed the same way.
 
 Examples:

--- a/docs/gradle-plugin/configuring.md
+++ b/docs/gradle-plugin/configuring.md
@@ -530,7 +530,7 @@ The `GroupingEntityType` type is used for this:
 If it is necessary to generate a report for a specific build variant using the Kover default report tasks, it is possible to combine the contents of the Android report and the default report.
 
 This is done by configuring default reports
-```
+```kotlin
 koverReport {
     defaults {
         mergeWith("release")
@@ -538,6 +538,24 @@ koverReport {
 }
 ```
 This will add the reports contents of `release` Android build variant to default reports.
+
+Is it acceptable to use wildcards `*` (zero or several arbitrary characters) and `?` (strictly one arbitrary character).
+The pattern is case-insensitive: `release` and `RelEase` processed the same way.
+
+Examples:
+- add coverage only of release build variant
+```kotlin
+  mergeWith("Release")
+```
+- add coverage of all build variants in the project
+```kotlin
+  mergeWith("*")
+```
+- add coverage of all build variants with build type `release` when there are different flavors
+```kotlin
+  mergeWith("*release")
+```
+
 
 This can be useful if only one command is run in a multimodule project for uniformity, instead of many different ones for each module.
 Or if in a multiplatform project it is necessary to generate a single report for JVM and Android targets.

--- a/kover-gradle-plugin/examples/android/all-variants-usage/app/build.gradle.kts
+++ b/kover-gradle-plugin/examples/android/all-variants-usage/app/build.gradle.kts
@@ -1,0 +1,68 @@
+plugins {
+    id ("com.android.application")
+    id ("org.jetbrains.kotlin.android")
+    id ("org.jetbrains.kotlinx.kover")
+}
+
+android {
+    namespace = "kotlinx.kover.test.android"
+    compileSdk = 32
+
+    defaultConfig {
+        applicationId = "kotlinx.kover.test.android"
+        minSdk = 21
+        targetSdk = 31
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+    buildFeatures {
+        viewBinding = true
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.8.0")
+    implementation("androidx.appcompat:appcompat:1.5.0")
+    implementation("com.google.android.material:material:1.6.1")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    testImplementation("junit:junit:4.13.2")
+}
+
+koverReport {
+    // filters for all report types of all build variants
+    filters {
+        excludes {
+            classes(
+                "*Fragment",
+                "*Fragment\$*",
+                "*Activity",
+                "*Activity\$*",
+                "*.databinding.*",
+                "*.BuildConfig"
+            )
+        }
+    }
+
+    defaults {
+        /**
+         * Tests, sources, classes, and compilation tasks of all build variants will be included in the default reports.
+         * Thus, information from all variants will be included in the default report for this project and any project that specifies this project as a dependency.
+         */
+        mergeWith("*")
+    }
+}

--- a/kover-gradle-plugin/examples/android/all-variants-usage/app/src/debug/kotlin/kotlinx/test/android/DebugAppClass.kt
+++ b/kover-gradle-plugin/examples/android/all-variants-usage/app/src/debug/kotlin/kotlinx/test/android/DebugAppClass.kt
@@ -1,0 +1,7 @@
+package kotlinx.kover.test.android
+
+object DebugAppClass {
+    fun foo() {
+        println("LIB DEBUG")
+    }
+}

--- a/kover-gradle-plugin/examples/android/all-variants-usage/app/src/main/AndroidManifest.xml
+++ b/kover-gradle-plugin/examples/android/all-variants-usage/app/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application android:label="@string/app_name">
+        <uses-library android:name="com.google.android.things" android:required="false" />
+
+        <activity android:name=".MainActivity"
+                  android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <!-- Make this the first activity that is displayed when the device boots. -->
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.HOME" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/kover-gradle-plugin/examples/android/all-variants-usage/app/src/main/java/kotlinx/kover/test/android/DebugUtil.kt
+++ b/kover-gradle-plugin/examples/android/all-variants-usage/app/src/main/java/kotlinx/kover/test/android/DebugUtil.kt
@@ -1,0 +1,7 @@
+package kotlinx.kover.test.android
+
+object DebugUtil {
+    fun log(message: String) {
+        println("DEBUG: $message")
+    }
+}

--- a/kover-gradle-plugin/examples/android/all-variants-usage/app/src/main/java/kotlinx/kover/test/android/MainActivity.kt
+++ b/kover-gradle-plugin/examples/android/all-variants-usage/app/src/main/java/kotlinx/kover/test/android/MainActivity.kt
@@ -1,0 +1,13 @@
+package kotlinx.kover.test.android
+
+import android.os.Bundle
+import android.app.Activity
+
+class MainActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+    }
+
+}

--- a/kover-gradle-plugin/examples/android/all-variants-usage/app/src/main/java/kotlinx/kover/test/android/Maths.kt
+++ b/kover-gradle-plugin/examples/android/all-variants-usage/app/src/main/java/kotlinx/kover/test/android/Maths.kt
@@ -1,0 +1,13 @@
+package kotlinx.kover.test.android
+
+object Maths {
+    fun sum(a: Int, b: Int): Int {
+        DebugUtil.log("invoked sum")
+        return a + b
+    }
+
+    fun sub(a: Int, b: Int): Int {
+        DebugUtil.log("invoked sub")
+        return a - b
+    }
+}

--- a/kover-gradle-plugin/examples/android/all-variants-usage/app/src/main/res/layout/activity_main.xml
+++ b/kover-gradle-plugin/examples/android/all-variants-usage/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:id="@+id/main_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="104dp"
+        android:layout_marginTop="28dp"
+        android:text="SERIALIZATION TEST"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <EditText
+        android:id="@+id/encoded_text"
+        android:layout_width="373dp"
+        android:layout_height="411dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:editable="false"
+        android:ems="10"
+        android:gravity="start|top"
+        android:inputType="textMultiLine"
+        android:textAlignment="viewStart"
+        android:textSize="12sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/main_label" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/kover-gradle-plugin/examples/android/all-variants-usage/app/src/main/res/values/colors.xml
+++ b/kover-gradle-plugin/examples/android/all-variants-usage/app/src/main/res/values/colors.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="purple_200">#FFBB86FC</color>
+    <color name="purple_500">#FF6200EE</color>
+    <color name="purple_700">#FF3700B3</color>
+    <color name="teal_200">#FF03DAC5</color>
+    <color name="teal_700">#FF018786</color>
+    <color name="black">#FF000000</color>
+    <color name="white">#FFFFFFFF</color>
+</resources>

--- a/kover-gradle-plugin/examples/android/all-variants-usage/app/src/main/res/values/strings.xml
+++ b/kover-gradle-plugin/examples/android/all-variants-usage/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Android Test</string>
+</resources>

--- a/kover-gradle-plugin/examples/android/all-variants-usage/app/src/main/res/values/themes.xml
+++ b/kover-gradle-plugin/examples/android/all-variants-usage/app/src/main/res/values/themes.xml
@@ -1,0 +1,4 @@
+<resources>
+
+    <style name="Theme.App" parent="android:Theme.Material.Light.DarkActionBar" />
+</resources>

--- a/kover-gradle-plugin/examples/android/all-variants-usage/app/src/test/java/kotlinx/kover/test/android/LocalTests.kt
+++ b/kover-gradle-plugin/examples/android/all-variants-usage/app/src/test/java/kotlinx/kover/test/android/LocalTests.kt
@@ -1,0 +1,13 @@
+package kotlinx.kover.test.android
+
+import org.junit.Test
+
+import org.junit.Assert.*
+
+
+class LocalTests {
+    @Test
+    fun testDebugUtils() {
+        assertEquals(3, Maths.sum(1, 2))
+    }
+}

--- a/kover-gradle-plugin/examples/android/all-variants-usage/build.gradle.kts
+++ b/kover-gradle-plugin/examples/android/all-variants-usage/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    id("com.android.application") version "7.4.0" apply false
+    id("com.android.library") version "7.4.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.8.20" apply false
+    id("org.jetbrains.kotlinx.kover") version "0.7.2" apply false
+}

--- a/kover-gradle-plugin/examples/android/all-variants-usage/gradle.properties
+++ b/kover-gradle-plugin/examples/android/all-variants-usage/gradle.properties
@@ -1,0 +1,23 @@
+# Project-wide Gradle settings.
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+# Kotlin code style for this project: "official" or "obsolete":
+kotlin.code.style=official
+# Enables namespacing of each library's R class so that its R class includes only the
+# resources declared in the library itself and none from the library's dependencies,
+# thereby reducing the size of the R class for that library
+android.nonTransitiveRClass=true

--- a/kover-gradle-plugin/examples/android/all-variants-usage/settings.gradle.kts
+++ b/kover-gradle-plugin/examples/android/all-variants-usage/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "all-variants-usage"
+include(":app")

--- a/kover-gradle-plugin/examples/android/variants-by-template-usage/app/build.gradle.kts
+++ b/kover-gradle-plugin/examples/android/variants-by-template-usage/app/build.gradle.kts
@@ -1,0 +1,78 @@
+plugins {
+    id ("com.android.application")
+    id ("org.jetbrains.kotlin.android")
+    id ("org.jetbrains.kotlinx.kover")
+}
+
+android {
+    namespace = "kotlinx.kover.test.android"
+    compileSdk = 32
+
+    defaultConfig {
+        applicationId = "kotlinx.kover.test.android"
+        minSdk = 21
+        targetSdk = 31
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        flavorDimensions += "dimension"
+        productFlavors {
+            create("first") {
+                dimension = "dimension"
+            }
+            create("second") {
+                dimension = "dimension"
+            }
+        }
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+    buildFeatures {
+        viewBinding = true
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.8.0")
+    implementation("androidx.appcompat:appcompat:1.5.0")
+    implementation("com.google.android.material:material:1.6.1")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    testImplementation("junit:junit:4.13.2")
+}
+
+koverReport {
+    // filters for all report types of all build variants
+    filters {
+        excludes {
+            classes(
+                "*Fragment",
+                "*Fragment\$*",
+                "*Activity",
+                "*Activity\$*",
+                "*.databinding.*",
+                "*.BuildConfig"
+            )
+        }
+    }
+
+    defaults {
+        /**
+         * Tests, sources, classes, and compilation tasks of all build variants will be included in the default reports.
+         * Thus, information from all variants will be included in the default report for this project and any project that specifies this project as a dependency.
+         */
+        mergeWith("*release")
+    }
+}

--- a/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/debug/kotlin/kotlinx/test/android/DebugAppClass.kt
+++ b/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/debug/kotlin/kotlinx/test/android/DebugAppClass.kt
@@ -1,0 +1,7 @@
+package kotlinx.kover.test.android
+
+object DebugAppClass {
+    fun foo() {
+        println("LIB DEBUG")
+    }
+}

--- a/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/main/AndroidManifest.xml
+++ b/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application android:label="@string/app_name">
+        <uses-library android:name="com.google.android.things" android:required="false" />
+
+        <activity android:name=".MainActivity"
+                  android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <!-- Make this the first activity that is displayed when the device boots. -->
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.HOME" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/main/java/kotlinx/kover/test/android/DebugUtil.kt
+++ b/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/main/java/kotlinx/kover/test/android/DebugUtil.kt
@@ -1,0 +1,7 @@
+package kotlinx.kover.test.android
+
+object DebugUtil {
+    fun log(message: String) {
+        println("DEBUG: $message")
+    }
+}

--- a/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/main/java/kotlinx/kover/test/android/MainActivity.kt
+++ b/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/main/java/kotlinx/kover/test/android/MainActivity.kt
@@ -1,0 +1,13 @@
+package kotlinx.kover.test.android
+
+import android.os.Bundle
+import android.app.Activity
+
+class MainActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+    }
+
+}

--- a/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/main/java/kotlinx/kover/test/android/Maths.kt
+++ b/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/main/java/kotlinx/kover/test/android/Maths.kt
@@ -1,0 +1,13 @@
+package kotlinx.kover.test.android
+
+object Maths {
+    fun sum(a: Int, b: Int): Int {
+        DebugUtil.log("invoked sum")
+        return a + b
+    }
+
+    fun sub(a: Int, b: Int): Int {
+        DebugUtil.log("invoked sub")
+        return a - b
+    }
+}

--- a/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/main/res/layout/activity_main.xml
+++ b/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:id="@+id/main_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="104dp"
+        android:layout_marginTop="28dp"
+        android:text="SERIALIZATION TEST"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <EditText
+        android:id="@+id/encoded_text"
+        android:layout_width="373dp"
+        android:layout_height="411dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:editable="false"
+        android:ems="10"
+        android:gravity="start|top"
+        android:inputType="textMultiLine"
+        android:textAlignment="viewStart"
+        android:textSize="12sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/main_label" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/main/res/values/colors.xml
+++ b/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/main/res/values/colors.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="purple_200">#FFBB86FC</color>
+    <color name="purple_500">#FF6200EE</color>
+    <color name="purple_700">#FF3700B3</color>
+    <color name="teal_200">#FF03DAC5</color>
+    <color name="teal_700">#FF018786</color>
+    <color name="black">#FF000000</color>
+    <color name="white">#FFFFFFFF</color>
+</resources>

--- a/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/main/res/values/strings.xml
+++ b/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Android Test</string>
+</resources>

--- a/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/main/res/values/themes.xml
+++ b/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/main/res/values/themes.xml
@@ -1,0 +1,4 @@
+<resources>
+
+    <style name="Theme.App" parent="android:Theme.Material.Light.DarkActionBar" />
+</resources>

--- a/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/test/java/kotlinx/kover/test/android/LocalTests.kt
+++ b/kover-gradle-plugin/examples/android/variants-by-template-usage/app/src/test/java/kotlinx/kover/test/android/LocalTests.kt
@@ -1,0 +1,13 @@
+package kotlinx.kover.test.android
+
+import org.junit.Test
+
+import org.junit.Assert.*
+
+
+class LocalTests {
+    @Test
+    fun testDebugUtils() {
+        assertEquals(3, Maths.sum(1, 2))
+    }
+}

--- a/kover-gradle-plugin/examples/android/variants-by-template-usage/build.gradle.kts
+++ b/kover-gradle-plugin/examples/android/variants-by-template-usage/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    id("com.android.application") version "7.4.0" apply false
+    id("com.android.library") version "7.4.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.8.20" apply false
+    id("org.jetbrains.kotlinx.kover") version "0.7.2" apply false
+}

--- a/kover-gradle-plugin/examples/android/variants-by-template-usage/gradle.properties
+++ b/kover-gradle-plugin/examples/android/variants-by-template-usage/gradle.properties
@@ -1,0 +1,23 @@
+# Project-wide Gradle settings.
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+# Kotlin code style for this project: "official" or "obsolete":
+kotlin.code.style=official
+# Enables namespacing of each library's R class so that its R class includes only the
+# resources declared in the library itself and none from the library's dependencies,
+# thereby reducing the size of the R class for that library
+android.nonTransitiveRClass=true

--- a/kover-gradle-plugin/examples/android/variants-by-template-usage/settings.gradle.kts
+++ b/kover-gradle-plugin/examples/android/variants-by-template-usage/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "all-variants-usage"
+include(":app")

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/VariantUsageTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/VariantUsageTests.kt
@@ -10,16 +10,16 @@ internal class VariantUsageTests {
     @ExamplesTest("android/variantUsage", [":app:koverXmlReport"])
     fun CheckerContext.testAndroidVariantUsage() {
         subproject(":app") {
+            // check test tasks
+            checkOutcome(":app:testDebugUnitTest", "SUCCESS")
+            checkOutcome(":lib:testDebugUnitTest", "SUCCESS")
+
+            // check artifact generation tasks
+            checkOutcome(":app:koverGenerateArtifactDebug", "SUCCESS")
+            checkOutcome(":lib:koverGenerateArtifactDebug", "SUCCESS")
+            checkOutcome(":app:koverGenerateArtifact", "SUCCESS")
+
             xmlReport {
-                // check test tasks
-                checkOutcome(":app:testDebugUnitTest", "SUCCESS")
-                checkOutcome(":lib:testDebugUnitTest", "SUCCESS")
-
-                // check artifact generation tasks
-                checkOutcome(":app:koverGenerateArtifactDebug", "SUCCESS")
-                checkOutcome(":lib:koverGenerateArtifactDebug", "SUCCESS")
-                checkOutcome(":app:koverGenerateArtifact", "SUCCESS")
-
                 classCounter("kotlinx.kover.test.android.DebugUtil").assertFullyCovered()
                 classCounter("kotlinx.kover.test.android.lib.DebugUtil").assertFullyCovered()
                 classCounter("kotlinx.kover.test.android.lib.DebugLibClass").assertFullyMissed()
@@ -28,18 +28,40 @@ internal class VariantUsageTests {
         }
     }
 
-    @ExamplesTest("android/multiplatform", [":koverXmlReport"])
-    fun CheckerContext.testMultiplatformVariantUsage() {
-        xmlReport {
+    @ExamplesTest("android/all-variants-usage", [":app:koverXmlReport"])
+    fun CheckerContext.testMergeAllVariants() {
+        subproject(":app") {
             // check test tasks
             checkOutcome(":app:testDebugUnitTest", "SUCCESS")
-            checkOutcome(":lib:testDebugUnitTest", "SUCCESS")
-
-            // check artifact generation tasks
-            checkOutcome(":lib:koverGenerateArtifactDebug", "SUCCESS")
+            checkOutcome(":app:testReleaseUnitTest", "SUCCESS")
             checkOutcome(":app:koverGenerateArtifactDebug", "SUCCESS")
-            checkOutcome(":app:koverGenerateArtifact", "SUCCESS")
+            checkOutcome(":app:koverGenerateArtifactRelease", "SUCCESS")
+        }
+    }
 
+    @ExamplesTest("android/variants-by-template-usage", [":app:koverXmlReport"])
+    fun CheckerContext.testMergeVariantsByTemplate() {
+        subproject(":app") {
+            // check test tasks
+            checkOutcome(":app:testFirstReleaseUnitTest", "SUCCESS")
+            checkOutcome(":app:testSecondReleaseUnitTest", "SUCCESS")
+            checkOutcome(":app:koverGenerateArtifactFirstRelease", "SUCCESS")
+            checkOutcome(":app:koverGenerateArtifactSecondRelease", "SUCCESS")
+        }
+    }
+
+    @ExamplesTest("android/multiplatform", [":koverXmlReport"])
+    fun CheckerContext.testMultiplatformVariantUsage() {
+        // check test tasks
+        checkOutcome(":app:testDebugUnitTest", "SUCCESS")
+        checkOutcome(":lib:testDebugUnitTest", "SUCCESS")
+
+        // check artifact generation tasks
+        checkOutcome(":lib:koverGenerateArtifactDebug", "SUCCESS")
+        checkOutcome(":app:koverGenerateArtifactDebug", "SUCCESS")
+        checkOutcome(":app:koverGenerateArtifact", "SUCCESS")
+
+        xmlReport {
             // check android classes from :lib
             classCounter("kotlinx.kover.test.android.lib.DebugUtil").assertFullyCovered()
             classCounter("kotlinx.kover.test.android.lib.DebugLibClass").assertFullyMissed()


### PR DESCRIPTION
Now it is possible to use wildcards `?` and `*` in the `mergeWith` function  and the check has become case-insensitive.

Relates #373