### PR TITLE
Fixing logging errors in the `BuildCacheRelocationTests` test

### DIFF
--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/BuildCacheRelocationTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/BuildCacheRelocationTests.kt
@@ -34,7 +34,7 @@ class BuildCacheRelocationTests {
             assertEquals("SUCCESS", result1.taskOutcome(":koverHtmlReport"))
             assertEquals("SUCCESS", result1.taskOutcome(":koverBinaryReport"))
             assertEquals("SUCCESS", result1.taskOutcome(":koverVerify"))
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             throw AssertionError("Build log \n${result1.output}",e)
         }
 
@@ -58,7 +58,7 @@ class BuildCacheRelocationTests {
             assertEquals("FROM-CACHE", result2.taskOutcome(":koverHtmlReport"))
             assertEquals("FROM-CACHE", result2.taskOutcome(":koverBinaryReport"))
             assertEquals("FROM-CACHE", result2.taskOutcome(":koverVerify"))
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             throw AssertionError("Build log \n${result2.output}",e)
         }
 


### PR DESCRIPTION
To display the build log, there is a need to catch an exception and add an output to the message.