### PR TITLE
Fixed applying of the root verification rules

### DIFF
--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/VerificationTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/VerificationTests.kt
@@ -5,8 +5,15 @@
 package kotlinx.kover.gradle.plugin.test.functional.cases
 
 import kotlinx.kover.gradle.plugin.dsl.*
+import kotlinx.kover.gradle.plugin.test.functional.framework.checker.CheckerContext
+import kotlinx.kover.gradle.plugin.test.functional.framework.checker.createCheckerContext
 import kotlinx.kover.gradle.plugin.test.functional.framework.configurator.*
+import kotlinx.kover.gradle.plugin.test.functional.framework.runner.buildFromTemplate
+import kotlinx.kover.gradle.plugin.test.functional.framework.runner.runWithParams
 import kotlinx.kover.gradle.plugin.test.functional.framework.starter.*
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 internal class VerificationTests {
     @SlicedGeneratedTest(allLanguages = true, allTools = true)
@@ -192,6 +199,18 @@ Rule violated: lines missed count for package 'org.jetbrains.kover.test.function
         }
 
         run("koverVerify")
+    }
+
+    /**
+     * In the common verify config, rules are declared that always lead to an error.
+     * Verification of the Android build variant should use these rules and failed.
+     */
+    @Test
+    fun testAndroidInverseOrder() {
+        val buildSource = buildFromTemplate("android-common-verify")
+        val build = buildSource.generate()
+        val buildResult = build.runWithParams(":app:koverVerifyRelease")
+        assertFalse(buildResult.isSuccessful)
     }
 
 }

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/build.gradle.kts
@@ -1,0 +1,59 @@
+plugins {
+    id ("org.jetbrains.kotlinx.kover")
+    id ("com.android.application")
+    id ("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "kotlinx.kover.test.android"
+    compileSdk = 32
+
+    defaultConfig {
+        applicationId = "kotlinx.kover.test.android"
+        minSdk = 21
+        targetSdk = 31
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+    buildFeatures {
+        viewBinding = true
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.8.0")
+    implementation("androidx.appcompat:appcompat:1.5.0")
+    implementation("com.google.android.material:material:1.6.1")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    testImplementation("junit:junit:4.13.2")
+}
+
+
+/*
+ * Kover configs
+ */
+
+koverReport {
+    verify {
+        rule {
+            // always fails
+            minBound(100)
+            maxBound(0)
+        }
+    }
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/main/AndroidManifest.xml
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application android:label="@string/app_name">
+        <uses-library android:name="com.google.android.things" android:required="false" />
+
+        <activity android:name=".MainActivity"
+                  android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <!-- Make this the first activity that is displayed when the device boots. -->
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.HOME" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/main/java/kotlinx/kover/test/android/DebugUtil.kt
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/main/java/kotlinx/kover/test/android/DebugUtil.kt
@@ -1,0 +1,7 @@
+package kotlinx.kover.test.android
+
+object DebugUtil {
+    fun log(message: String) {
+        println("DEBUG: $message")
+    }
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/main/java/kotlinx/kover/test/android/MainActivity.kt
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/main/java/kotlinx/kover/test/android/MainActivity.kt
@@ -1,0 +1,13 @@
+package kotlinx.kover.test.android
+
+import android.os.Bundle
+import android.app.Activity
+
+class MainActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+    }
+
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/main/java/kotlinx/kover/test/android/Maths.kt
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/main/java/kotlinx/kover/test/android/Maths.kt
@@ -1,0 +1,13 @@
+package kotlinx.kover.test.android
+
+object Maths {
+    fun sum(a: Int, b: Int): Int {
+        DebugUtil.log("invoked sum")
+        return a + b
+    }
+
+    fun sub(a: Int, b: Int): Int {
+        DebugUtil.log("invoked sub")
+        return a - b
+    }
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/main/res/layout/activity_main.xml
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:id="@+id/main_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="104dp"
+        android:layout_marginTop="28dp"
+        android:text="SERIALIZATION TEST"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <EditText
+        android:id="@+id/encoded_text"
+        android:layout_width="373dp"
+        android:layout_height="411dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:editable="false"
+        android:ems="10"
+        android:gravity="start|top"
+        android:inputType="textMultiLine"
+        android:textAlignment="viewStart"
+        android:textSize="12sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/main_label" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/main/res/values/colors.xml
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/main/res/values/colors.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="purple_200">#FFBB86FC</color>
+    <color name="purple_500">#FF6200EE</color>
+    <color name="purple_700">#FF3700B3</color>
+    <color name="teal_200">#FF03DAC5</color>
+    <color name="teal_700">#FF018786</color>
+    <color name="black">#FF000000</color>
+    <color name="white">#FFFFFFFF</color>
+</resources>

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/main/res/values/strings.xml
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Android Test</string>
+</resources>

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/main/res/values/themes.xml
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/main/res/values/themes.xml
@@ -1,0 +1,4 @@
+<resources>
+
+    <style name="Theme.App" parent="android:Theme.Material.Light.DarkActionBar" />
+</resources>

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/test/java/kotlinx/kover/test/android/LocalTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/app/src/test/java/kotlinx/kover/test/android/LocalTests.kt
@@ -1,0 +1,13 @@
+package kotlinx.kover.test.android
+
+import org.junit.Test
+
+import org.junit.Assert.*
+
+
+class LocalTests {
+    @Test
+    fun testDebugUtils() {
+        assertEquals(3, Maths.sum(1, 2))
+    }
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    id("com.android.application") version "7.4.0" apply false
+    id("com.android.library") version "7.4.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.8.20" apply false
+    id("org.jetbrains.kotlinx.kover") version "0.7.1" apply false
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/gradle.properties
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/gradle.properties
@@ -1,0 +1,23 @@
+# Project-wide Gradle settings.
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+# Kotlin code style for this project: "official" or "obsolete":
+kotlin.code.style=official
+# Enables namespacing of each library's R class so that its R class includes only the
+# resources declared in the library itself and none from the library's dependencies,
+# thereby reducing the size of the R class for that library
+android.nonTransitiveRClass=true

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/settings.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-common-verify/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "android_kts"
+include(":app")

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/reports/AndroidVariantApplier.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/reports/AndroidVariantApplier.kt
@@ -85,10 +85,6 @@ internal fun ObjectFactory.androidReports(variant: String, layout: ProjectLayout
         onCheck = false
     }
 
-    reports.verify {
-        onCheck = false
-    }
-
     return reports
 }
 


### PR DESCRIPTION
Now, when creating the Android report configuration, on Check is immediately set for verification.

This is not necessary, because if not specified, only the `koverVerify` task is started when executing check, but not the tasks of verifying Android build variant. This has a negative side effect, because the verification for the build variant is always specify, and it will override the common rules from the root of the report config `koverReport { verify { /* common rules */ }  }`

Fixes #459