### PR TITLE
Update Gradle Dokka configuration to make sure "source" button is visible in all API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ out/
 # Gradle files
 build/
 .gradle/
+
+# generated dokka documentation
+/docs/gradle-plugin/dokka/

--- a/kover-gradle-plugin/build.gradle.kts
+++ b/kover-gradle-plugin/build.gradle.kts
@@ -158,10 +158,8 @@ tasks.dokkaHtml {
             skipDeprecated.set(true)
         }
         sourceLink {
-            val sourcesPath = "src/$name/kotlin"
-            val relPath = rootProject.projectDir.toPath().relativize(projectDir.toPath())
-            localDirectory.set(projectDir.resolve(sourcesPath))
-            remoteUrl.set(URL("https://github.com/kotlin/kotlinx-kover/tree/main/$relPath/$sourcesPath"))
+            localDirectory.set(rootDir)
+            remoteUrl.set(URL("https://github.com/kotlin/kotlinx-kover/tree/main"))
             remoteLineSuffix.set("#L")
         }
     }

--- a/kover-gradle-plugin/build.gradle.kts
+++ b/kover-gradle-plugin/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.net.*
 
 plugins {
     kotlin("jvm")
@@ -155,6 +156,13 @@ tasks.dokkaHtml {
         // source set configuration section
         perPackageOption {
             skipDeprecated.set(true)
+        }
+        sourceLink {
+            val sourcesPath = "src/$name/kotlin"
+            val relPath = rootProject.projectDir.toPath().relativize(projectDir.toPath())
+            localDirectory.set(projectDir.resolve(sourcesPath))
+            remoteUrl.set(URL("https://github.com/kotlin/kotlinx-kover/tree/main/$relPath/$sourcesPath"))
+            remoteLineSuffix.set("#L")
         }
     }
 }


### PR DESCRIPTION
For context: https://github.com/Kotlin/kotlinx.coroutines/issues/3929 and https://github.com/Kotlin/kotlinx.coroutines/pull/3960

BTW, is there a reason why `kover` API reference is not published under `https://kotlinlang.org/docs/home.html` API reference section?