### PR TITLE
Fixed `Stream closed` error  when generating Kover HTML report

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-intellij-coverage = "1.0.741"
+intellij-coverage = "1.0.748"
 junit = "5.9.0"
 kotlinx-bcv = "0.13.2"
 kotlinx-dokka = "1.8.10"

--- a/kover-cli/src/main/kotlin/kotlinx/kover/cli/commands/ReportCommand.kt
+++ b/kover-cli/src/main/kotlin/kotlinx/kover/cli/commands/ReportCommand.kt
@@ -47,8 +47,8 @@ internal class ReportCommand : Command {
     @Option(name = "--html", usage = "generate a HTML report in the specified path", metaVar = "<html-dir>")
     private var htmlDir: File? = null
 
-    @Option(name = "--title", usage = "title in the HTML report", metaVar = "<html-title>")
-    private var htmlTitle: String? = null
+    @Option(name = "--title", usage = "title in the HTML or XML report", metaVar = "<title>")
+    private var title: String? = null
 
     @Option(
         name = "--include",
@@ -85,7 +85,7 @@ internal class ReportCommand : Command {
         var fail = false
         if (xmlFile != null) {
             try {
-                ReportApi.xmlReport(xmlFile, binaryReports, outputRoots, sourceRoots, filters)
+                ReportApi.xmlReport(xmlFile, title ?: "Kover XML Report", binaryReports, outputRoots, sourceRoots, filters)
             } catch (e: IOException) {
                 fail = true
                 errorWriter.println("XML generation failed: " + e.message)
@@ -93,7 +93,7 @@ internal class ReportCommand : Command {
         }
         if (htmlDir != null) {
             try {
-                ReportApi.htmlReport(htmlDir, htmlTitle, null, binaryReports, outputRoots, sourceRoots, filters)
+                ReportApi.htmlReport(htmlDir, title, null, binaryReports, outputRoots, sourceRoots, filters)
             } catch (e: IOException) {
                 fail = true
                 errorWriter.println("HTML generation failed: " + e.message)

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverVersions.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverVersions.kt
@@ -15,7 +15,7 @@ public object KoverVersions {
     /**
      * Kover coverage tool version.
      */
-    public const val KOVER_TOOL_VERSION = "1.0.741"
+    public const val KOVER_TOOL_VERSION = "1.0.748"
 
     /**
      * JaCoCo coverage tool version used by default.

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/kover/KoverHtmlOrXmlReport.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/kover/KoverHtmlOrXmlReport.kt
@@ -53,6 +53,7 @@ internal abstract class XmlReportAction : AbstractReportAction<XmlReportParamete
 
         ReportApi.xmlReport(
             parameters.xmlFile.get().asFile,
+            parameters.projectPath.get(),
             files.reports.toList(),
             files.outputs.toList(),
             files.sources.toList(),
@@ -68,6 +69,10 @@ internal abstract class HtmlReportAction : AbstractReportAction<HtmlReportParame
 
         val files = parameters.files.get()
         val filters = parameters.filters.get()
+
+        // repeat reading freemarker temple from resources if error occurred, see https://github.com/Kotlin/kotlinx-kover/issues/510
+        // the values are selected empirically so that the maximum report generation time is not much more than a second
+        ReportApi.setFreemarkerRetry(7, 150)
 
         ReportApi.htmlReport(
             parameters.htmlDir.get().asFile,


### PR DESCRIPTION
When generating an HTML report, errors sometimes occur when reading the freemarker template from resources. The exact cause of the error has not yet been determined (relates to the Gradle isolated class loaders), but it disappears when you try to read again. In some cases, it is necessary to increase the number of repetitions, so this setting was made in Kover Gradle plugin.

Fixes #510