### PR TITLE
Fixed the presence of classes instrumented with Robolectric in Jacoco reports

### DIFF
--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/JvmTestTaskConfigurator.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/JvmTestTaskConfigurator.kt
@@ -45,8 +45,14 @@ internal class JvmTestTaskConfigurator(
             binReportProvider.get().asFile.delete()
         }
 
-        // Always excludes android classes, see https://github.com/Kotlin/kotlinx-kover/issues/89
-        val excluded = data.excludedClasses + listOf("android.*", "com.android.*")
+
+        val excluded = data.excludedClasses +
+                listOf(
+                    // Always excludes android classes, see https://github.com/Kotlin/kotlinx-kover/issues/89
+                    "android.*", "com.android.*",
+                    // excludes JVM internal classes, in some cases, errors occur when trying to instrument these classes, for example, when using JaCoCo + Robolectric. There is also no point in instrumenting them in Kover.
+                    "jdk.internal.*"
+                )
 
         testTask.jvmArgumentProviders += JvmTestTaskArgumentProvider(
             testTask.temporaryDir,

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/jacoco/JacocoOnlineInstrumentation.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/jacoco/JacocoOnlineInstrumentation.kt
@@ -8,7 +8,7 @@ import java.io.*
 
 internal fun buildJvmAgentArgs(jarFile: File, binReportFile: File, excludedClasses: Set<String>): List<String> {
     val agentArgs = listOfNotNull(
-        "destfile=${binReportFile.canonicalPath},append=true,inclnolocationclasses=false,dumponexit=true,output=file,jmx=false",
+        "destfile=${binReportFile.canonicalPath},append=true,inclnolocationclasses=true,dumponexit=true,output=file,jmx=false",
         excludedClasses.joinToFilterString("excludes")
     ).joinToString(",")
 


### PR DESCRIPTION
It seems that after Robolectric instrumentation, source locations are lost and JaCoCo does not instrument such classes by default. There is a need to change the flag to disable this behavior.

After changing this flag, errors occur in the instrumentation of JVM classes (because they were previously excluded due to the lack of sources). The package with these classes was determined empirically.

Fixes #530