### PR TITLE
Fixed package exclusion in reports for JaCoCo

### DIFF
--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ReportsFilteringTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ReportsFilteringTests.kt
@@ -147,4 +147,33 @@ internal class ReportsFilteringTests {
         }
     }
 
+
+    /**
+     * Check that when excluding packages, the excluding occurs starting from the root package,
+     * and there is no search for any middle occurrence of the specified string.
+     *
+     * See https://github.com/Kotlin/kotlinx-kover/issues/543
+     */
+    @SlicedGeneratedTest(allTools = true)
+    fun BuildConfigurator.testPackageInTheMiddle() {
+        addProjectWithKover {
+            sourcesFrom("different-packages")
+
+            koverReport {
+                filters {
+                    excludes {
+                        packages("foo")
+                    }
+                }
+
+            }
+        }
+        run("koverXmlReport") {
+            xmlReport {
+                classCounter("foo.bar.FooClass").assertAbsent()
+                classCounter("org.jetbrains.foo.ExampleClass").assertCovered()
+            }
+        }
+    }
+
 }

--- a/kover-gradle-plugin/src/functionalTest/templates/sources/different-packages/main/kotlin/FooSources.kt
+++ b/kover-gradle-plugin/src/functionalTest/templates/sources/different-packages/main/kotlin/FooSources.kt
@@ -1,0 +1,8 @@
+package foo.bar
+
+class FooClass {
+    fun function() {
+        println("Hello")
+    }
+
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/sources/different-packages/main/kotlin/Sources.kt
+++ b/kover-gradle-plugin/src/functionalTest/templates/sources/different-packages/main/kotlin/Sources.kt
@@ -1,0 +1,11 @@
+package org.jetbrains.foo
+
+class ExampleClass {
+    fun used(value: Int): Int {
+        return value + 1
+    }
+
+    fun unused(value: Long): Long {
+        return value - 1
+    }
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/sources/different-packages/test/kotlin/TestClass.kt
+++ b/kover-gradle-plugin/src/functionalTest/templates/sources/different-packages/test/kotlin/TestClass.kt
@@ -1,0 +1,14 @@
+package org.jetbrains.serialuser
+
+import org.jetbrains.foo.ExampleClass
+import foo.bar.FooClass
+import kotlin.test.Test
+
+class TestClass {
+    @Test
+    fun simpleTest() {
+        ExampleClass().used(-20)
+        FooClass().function()
+    }
+
+}

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/util/Util.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/util/Util.kt
@@ -32,14 +32,6 @@ internal inline fun <T : Any> Boolean.ifFalse(block: () -> T): T? {
 }
 
 /**
- * Replaces characters `.` to `|` or `\` and added `.class` as postfix and `.* /` or `.*\` as prefix.
- */
-internal fun String.wildcardsToClassFileRegex(): String {
-    val filenameWithWildcards = "*" + File.separatorChar + this.replace('.', File.separatorChar) + ".class"
-    return filenameWithWildcards.wildcardsToRegex()
-}
-
-/**
  * Replaces characters `*` or `.` to `.*` and `.` regexp characters.
  */
 internal fun String.wildcardsToRegex(): String {


### PR DESCRIPTION
Class filtering in JaCoCo took place by file name. Because previously the absolute path to the class file was taken, the filter worked on any occurrence of the specified string, even if it was no match starting from the root package.

Now the search takes place relative to the classes root directory, which allows you to change the regular expression of the search, and remove arbitrary characters at the beginning in it.

Fixes #543