### PR TITLE
Repacked the intellij-agent artifact to kover-jvm-agent

### DIFF
--- a/build-logic/src/main/kotlin/kotlinx/kover/conventions/kover-docs-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlinx/kover/conventions/kover-docs-conventions.gradle.kts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+interface KoverDocsExtension {
+    val docsDirectory: Property<String>
+    val description: Property<String>
+    val callDokkaHtml: Property<Boolean>
+}
+
+val extension = extensions.create<KoverDocsExtension>("koverDocs")
+
+extension.callDokkaHtml.convention(false)
+
+tasks.register("releaseDocs") {
+    dependsOn(
+        tasks.matching { extension.callDokkaHtml.get() && it.name == "dokkaHtml" }
+    )
+
+    doLast {
+        val dirName = extension.docsDirectory.get()
+        val description = extension.description.get()
+
+        val sourceDir = projectDir.resolve("docs")
+        val resultDir = rootDir.resolve("docs/$dirName")
+        val mainIndexFile = rootDir.resolve("docs/index.md")
+
+        resultDir.mkdirs()
+        sourceDir.copyRecursively(resultDir)
+        mainIndexFile.appendText("- [$description]($dirName)\n")
+    }
+}

--- a/build-logic/src/main/kotlin/kotlinx/kover/conventions/kover-fat-jar-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlinx/kover/conventions/kover-fat-jar-conventions.gradle.kts
@@ -1,3 +1,7 @@
+import org.gradle.kotlin.dsl.base
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.java
+
 /*
  * Copyright 2000-2023 JetBrains s.r.o.
  *
@@ -16,29 +20,11 @@
 
 plugins {
     java
-    id("kover-publishing-conventions")
-}
-
-extensions.configure<Kover_publishing_conventions_gradle.KoverPublicationExtension> {
-    description.set("Compiled dependency to ensure the operation of the code that has been instrumented offline")
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_7
-    targetCompatibility = JavaVersion.VERSION_1_7
-}
-
-repositories {
-    mavenCentral()
 }
 
 val fatJarDependency = "fatJar"
 val fatJarConfiguration = configurations.create(fatJarDependency)
 
-dependencies {
-    compileOnly(libs.intellij.offline)
-    fatJarConfiguration(libs.intellij.offline)
-}
 
 tasks.jar {
     from(
@@ -48,19 +34,5 @@ tasks.jar {
         exclude("META-INF/**")
         exclude("LICENSE")
         exclude("classpath.index")
-    }
-}
-
-tasks.register("releaseDocs") {
-    val dirName = "offline-instrumentation"
-    val description = "Kover offline instrumentation"
-    val sourceDir = projectDir.resolve("docs")
-    val resultDir = rootDir.resolve("docs/$dirName")
-    val mainIndexFile = rootDir.resolve("docs/index.md")
-
-    doLast {
-        resultDir.mkdirs()
-        sourceDir.copyRecursively(resultDir)
-        mainIndexFile.appendText("- [$description]($dirName)\n")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ gradle-plugin-publish = "1.2.1"
 [libraries]
 
 # IntelliJ coverage library
+intellij-agent = { module = "org.jetbrains.intellij.deps:intellij-coverage-agent", version.ref = "intellij-coverage" }
 intellij-reporter = { module = "org.jetbrains.intellij.deps:intellij-coverage-reporter", version.ref = "intellij-coverage" }
 intellij-offline = { module = "org.jetbrains.intellij.deps:intellij-coverage-offline", version.ref = "intellij-coverage" }
 

--- a/kover-cli/build.gradle.kts
+++ b/kover-cli/build.gradle.kts
@@ -23,7 +23,6 @@ plugins {
 
 extensions.configure<Kover_publishing_conventions_gradle.KoverPublicationExtension> {
     description.set("Command Line Interface for Kotlin Coverage Toolchain")
-    fatJar.set(true)
 }
 
 kotlin {

--- a/kover-cli/build.gradle.kts
+++ b/kover-cli/build.gradle.kts
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     kotlin("jvm")
     id("kover-publishing-conventions")
+    id("kover-docs-conventions")
 }
 
 extensions.configure<Kover_publishing_conventions_gradle.KoverPublicationExtension> {
@@ -63,16 +64,7 @@ repositories {
     mavenCentral()
 }
 
-tasks.register("releaseDocs") {
-    val dirName = "cli"
-    val description = "Kover Command Line Interface"
-    val sourceDir = projectDir.resolve("docs")
-    val resultDir = rootDir.resolve("docs/$dirName")
-    val mainIndexFile = rootDir.resolve("docs/index.md")
-
-    doLast {
-        resultDir.mkdirs()
-        sourceDir.copyRecursively(resultDir)
-        mainIndexFile.appendText("- [$description]($dirName)\n")
-    }
+extensions.configure<Kover_docs_conventions_gradle.KoverDocsExtension> {
+    docsDirectory.set("cli")
+    description.set("Kover Command Line Interface")
 }

--- a/kover-cli/build.gradle.kts
+++ b/kover-cli/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
     kotlin("jvm")
     id("kover-publishing-conventions")
     id("kover-docs-conventions")
+    id("kover-fat-jar-conventions")
 }
 
 extensions.configure<Kover_publishing_conventions_gradle.KoverPublicationExtension> {
@@ -33,9 +34,16 @@ kotlin {
 }
 
 dependencies {
-    implementation(project(":kover-features-jvm"))
+    compileOnly(kotlin("stdlib"))
+    fatJar(kotlin("stdlib"))
 
-    implementation(libs.args4j)
+    fatJar(project(":kover-features-jvm"))
+    compileOnly(project(":kover-features-jvm"))
+    testImplementation(project(":kover-features-jvm"))
+
+    fatJar(libs.args4j)
+    compileOnly(libs.args4j)
+    testImplementation(libs.args4j)
 
     testImplementation(kotlin("test"))
 }
@@ -49,14 +57,6 @@ tasks.withType<KotlinCompile>().configureEach {
 tasks.jar {
     manifest {
         attributes("Main-Class" to "kotlinx.kover.cli.MainKt")
-    }
-
-    from(
-        configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) }
-    ) {
-        exclude("OSGI-OPT/**")
-        exclude("META-INF/**")
-        exclude("LICENSE")
     }
 }
 

--- a/kover-features-jvm/build.gradle.kts
+++ b/kover-features-jvm/build.gradle.kts
@@ -21,7 +21,6 @@ plugins {
 
 extensions.configure<Kover_publishing_conventions_gradle.KoverPublicationExtension> {
     description.set("Implementation of calling the main features of Kover programmatically")
-    fatJar.set(true)
 }
 
 java {
@@ -40,10 +39,10 @@ tasks.processResources {
         project.version.toString()
     }
 
-    filesMatching("**/kover.version") {
-        filter {
-            it.replace("\$version", version)
-        }
+    val file = destinationDir.resolve("kover.version")
+
+    doLast {
+        file.writeText(version)
     }
 }
 

--- a/kover-features-jvm/src/main/resources/kover.version
+++ b/kover-features-jvm/src/main/resources/kover.version
@@ -1,1 +1,0 @@
-$version

--- a/kover-gradle-plugin/api/kover-gradle-plugin.api
+++ b/kover-gradle-plugin/api/kover-gradle-plugin.api
@@ -225,6 +225,7 @@ public final class kotlinx/kover/gradle/plugin/dsl/KoverVersions {
 	public static final field JACOCO_TOOL_DEFAULT_VERSION Ljava/lang/String;
 	public static final field KOVER_TOOL_VERSION Ljava/lang/String;
 	public static final field MINIMUM_GRADLE_VERSION Ljava/lang/String;
+	public final fun getVersion ()Ljava/lang/String;
 }
 
 public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverXmlTaskConfig {

--- a/kover-gradle-plugin/build.gradle.kts
+++ b/kover-gradle-plugin/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     `java-gradle-plugin`
     alias(libs.plugins.gradle.pluginPublish)
     id("kover-publishing-conventions")
+    id("kover-docs-conventions")
 }
 
 repositories {
@@ -167,20 +168,10 @@ tasks.dokkaHtml {
     }
 }
 
-tasks.register("releaseDocs") {
-    val dirName = "gradle-plugin"
-    val description = "Kover Gradle Plugin"
-    val sourceDir = projectDir.resolve("docs")
-    val resultDir = rootDir.resolve("docs/$dirName")
-    val mainIndexFile = rootDir.resolve("docs/index.md")
-
-    dependsOn(tasks.dokkaHtml)
-
-    doLast {
-        resultDir.mkdirs()
-        sourceDir.copyRecursively(resultDir)
-        mainIndexFile.appendText("- [$description]($dirName)\n")
-    }
+extensions.configure<Kover_docs_conventions_gradle.KoverDocsExtension> {
+    docsDirectory.set("gradle-plugin")
+    description.set("Kover Gradle Plugin")
+    callDokkaHtml.set(true)
 }
 
 extensions.configure<Kover_publishing_conventions_gradle.KoverPublicationExtension> {

--- a/kover-gradle-plugin/examples/jvm/merged/build.gradle.kts
+++ b/kover-gradle-plugin/examples/jvm/merged/build.gradle.kts
@@ -3,10 +3,6 @@ plugins {
     id("org.jetbrains.kotlinx.kover") version "0.7.6"
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation(project(":subproject"))
     implementation(project(":excluded"))

--- a/kover-gradle-plugin/examples/jvm/merged/excluded/build.gradle.kts
+++ b/kover-gradle-plugin/examples/jvm/merged/excluded/build.gradle.kts
@@ -1,7 +1,3 @@
 plugins {
     kotlin("jvm")
 }
-
-repositories {
-    mavenCentral()
-}

--- a/kover-gradle-plugin/examples/jvm/merged/settings.gradle.kts
+++ b/kover-gradle-plugin/examples/jvm/merged/settings.gradle.kts
@@ -8,3 +8,9 @@ rootProject.name = "example-merged"
 
 include(":subproject")
 include(":excluded")
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/kover-gradle-plugin/examples/jvm/merged/subproject/build.gradle.kts
+++ b/kover-gradle-plugin/examples/jvm/merged/subproject/build.gradle.kts
@@ -3,10 +3,6 @@ plugins {
     id("org.jetbrains.kotlinx.kover")
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     testImplementation(kotlin("test"))
 }

--- a/kover-gradle-plugin/examples/jvm/minimal/build.gradle.kts
+++ b/kover-gradle-plugin/examples/jvm/minimal/build.gradle.kts
@@ -3,10 +3,6 @@ plugins {
     id("org.jetbrains.kotlinx.kover") version "0.7.6"
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     testImplementation(kotlin("test"))
 }

--- a/kover-gradle-plugin/examples/jvm/minimal/settings.gradle.kts
+++ b/kover-gradle-plugin/examples/jvm/minimal/settings.gradle.kts
@@ -6,3 +6,8 @@ pluginManagement {
 }
 rootProject.name = "example-minimal"
 
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/AccessorsTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/AccessorsTests.kt
@@ -23,10 +23,6 @@ internal class AccessorsTests {
                     id("org.jetbrains.kotlinx.kover")
                 }
 
-                repositories {
-                    mavenCentral()
-                }
-
                 tasks.register("custom") {
                     dependsOn(tasks.koverHtmlReport)
                     dependsOn(tasks.koverXmlReport)

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/common/Environment.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/common/Environment.kt
@@ -4,6 +4,7 @@
 
 package kotlinx.kover.gradle.plugin.test.functional.framework.common
 
+import org.gradle.kotlin.dsl.provideDelegate
 import java.io.File
 
 /**
@@ -59,8 +60,12 @@ internal val isAndroidTestDisabled: Boolean = System.getProperty("kover.test.and
 /**
  * Path to the local maven repository with the current Kover build.
  */
-internal val localRepositoryPath: String = System.getProperty("localRepositoryPath")
-    ?: throw Exception("System property 'localRepositoryPath' not defined for functional tests")
+internal val snapshotRepositoriesPropertyValue: List<String> by lazy {
+    val value = System.getProperty("snapshotRepositories")
+        ?: throw Exception("System property 'localRepositoryPath' not defined for functional tests")
+
+    value.split("\n")
+}
 
 
 internal fun logInfo(message: String) {

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/configurator/BuildConfigurator.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/configurator/BuildConfigurator.kt
@@ -77,10 +77,6 @@ private open class TestBuildConfigurator : BuildConfigurator {
                 }
             }
 
-            repositories {
-                repository("mavenCentral()")
-            }
-
             generator()
         }
     }

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/runner/BuildsRunner.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/runner/BuildsRunner.kt
@@ -16,8 +16,8 @@ import java.io.File
 import java.nio.file.Files
 
 
-internal fun createBuildSource(localMavenDir: String, koverVersion: String): BuildSource {
-    return BuildSourceImpl(localMavenDir, koverVersion)
+internal fun createBuildSource(snapshotRepos: List<String>, koverVersion: String): BuildSource {
+    return BuildSourceImpl(snapshotRepos, koverVersion)
 }
 
 internal interface BuildSource {
@@ -49,7 +49,7 @@ internal data class BuildEnv(
     val disableBuildCacheByDefault: Boolean = true
 )
 
-private class BuildSourceImpl(val localMavenDir: String, val koverVersion: String) : BuildSource {
+private class BuildSourceImpl(val snapshotRepos: List<String>, val koverVersion: String) : BuildSource {
     private var dir: File? = null
 
     private var copy: Boolean = false
@@ -82,12 +82,11 @@ private class BuildSourceImpl(val localMavenDir: String, val koverVersion: Strin
 
         targetDir.settings.patchSettingsFile(
             "$buildType '$buildName', project dir: ${targetDir.uri}",
-            koverVersion, localMavenDir, overriddenKotlinVersion
+            koverVersion, snapshotRepos, overriddenKotlinVersion
         )
 
         val buildSrcScript = targetDir.buildSrc?.build
         buildSrcScript?.patchKoverDependency(koverVersion)
-        buildSrcScript?.addLocalRepository(localMavenDir)
 
         return GradleBuildImpl(targetDir, copy, buildName, buildType)
     }

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/runner/CustomizableRunning.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/runner/CustomizableRunning.kt
@@ -10,7 +10,7 @@ import kotlinx.kover.gradle.plugin.test.functional.framework.common.koverVersion
 import kotlinx.kover.gradle.plugin.test.functional.framework.common.defaultGradleWrapperDir
 import kotlinx.kover.gradle.plugin.test.functional.framework.common.examplesDir
 import kotlinx.kover.gradle.plugin.test.functional.framework.common.overriddenGradleVersion
-import kotlinx.kover.gradle.plugin.test.functional.framework.common.localRepositoryPath
+import kotlinx.kover.gradle.plugin.test.functional.framework.common.snapshotRepositoriesPropertyValue
 import kotlinx.kover.gradle.plugin.test.functional.framework.common.overriddenKotlinVersion
 import kotlinx.kover.gradle.plugin.test.functional.framework.common.templateBuildsDir
 import kotlinx.kover.gradle.plugin.util.SemVer
@@ -19,7 +19,7 @@ import java.io.File
 import java.nio.file.Files
 
 internal fun buildFromTemplate(templateName: String): BuildSource {
-    val source = createBuildSource(localRepositoryPath, koverVersionCurrent)
+    val source = createBuildSource(snapshotRepositoriesPropertyValue, koverVersionCurrent)
     source.overriddenKotlinVersion = overriddenKotlinVersion
 
     val dir = templateBuildsDir.resolve(templateName)
@@ -34,7 +34,7 @@ internal fun buildFromTemplate(templateName: String): BuildSource {
 }
 
 internal fun buildFromExample(examplePath: String): BuildSource {
-    val source = createBuildSource(localRepositoryPath, koverVersionCurrent)
+    val source = createBuildSource(snapshotRepositoriesPropertyValue, koverVersionCurrent)
     source.overriddenKotlinVersion = overriddenKotlinVersion
 
     val exampleDir = examplesDir.resolve(examplePath)
@@ -50,7 +50,7 @@ internal fun generateBuild(generator: (File) -> Unit): BuildSource {
     val dir = Files.createTempDirectory("generated-build-").toFile()
 
     generator(dir)
-    val source = createBuildSource(localRepositoryPath, koverVersionCurrent)
+    val source = createBuildSource(snapshotRepositoriesPropertyValue, koverVersionCurrent)
     source.overriddenKotlinVersion = overriddenKotlinVersion
     source.buildType = "generated"
     source.from(dir)

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/writer/SettingsWriter.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/framework/writer/SettingsWriter.kt
@@ -10,7 +10,7 @@ import java.io.*
 
 internal fun FormattedWriter.writePluginManagement(language: ScriptLanguage,
                                                    koverVersion: String,
-                                                   localRepositoryPath: String,
+                                                   snapshotRepos: List<String>,
                                                    overrideKotlinVersion: String?) {
     call("resolutionStrategy") {
         call("eachPlugin") {
@@ -24,9 +24,22 @@ internal fun FormattedWriter.writePluginManagement(language: ScriptLanguage,
     }
 
     call("repositories") {
-        line("maven { url=${localRepositoryPath.uriForScript(language)} }")
+        snapshotRepos.forEach { repo ->
+            line("maven { url=${repo.uriForScript(language)} }")
+        }
         line("gradlePluginPortal()")
         line("mavenCentral()")
+    }
+}
+
+internal fun FormattedWriter.writeDependencyManagement(language: ScriptLanguage, snapshotRepos: List<String>) {
+    call("dependencyResolutionManagement") {
+        call("repositories") {
+            snapshotRepos.forEach { repo ->
+                line("maven { url=${repo.uriForScript(language)} }")
+            }
+            line("mavenCentral()")
+        }
     }
 }
 

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
 
 apply(plugin = "org.jetbrains.kotlinx.kover")
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.0")
 }

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/buildSrc/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/buildsrc-usage/buildSrc/build.gradle.kts
@@ -2,10 +2,6 @@ plugins {
     kotlin("jvm") version "1.4.20"
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation("org.jetbrains.kotlinx:kover-gradle-plugin:TEST")
 }

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/counters/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/counters/build.gradle.kts
@@ -3,10 +3,6 @@ plugins {
     id("org.jetbrains.kotlinx.kover")
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     testImplementation(kotlin("test"))
 }

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/different-plugins/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/different-plugins/build.gradle.kts
@@ -2,10 +2,6 @@ plugins {
     id("org.jetbrains.kotlinx.kover")
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     kover(project(":subproject-multiplatform"))
 }

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/different-plugins/subproject-multiplatform/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/different-plugins/subproject-multiplatform/build.gradle.kts
@@ -3,10 +3,6 @@ plugins {
     id("org.jetbrains.kotlinx.kover")
 }
 
-repositories {
-    mavenCentral()
-}
-
 kotlin {
     jvm()
 

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/nested-project/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/nested-project/build.gradle.kts
@@ -3,10 +3,6 @@ plugins {
     id("org.jetbrains.kotlinx.kover")
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     kover(project(":subprojects:alpha-project"))
 }

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/nested-project/subprojects/alpha-project/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/nested-project/subprojects/alpha-project/build.gradle.kts
@@ -3,10 +3,6 @@ plugins {
     id("org.jetbrains.kotlinx.kover")
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     testImplementation(kotlin("test"))
 }

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/no-dependency-jvm/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/no-dependency-jvm/build.gradle.kts
@@ -3,10 +3,6 @@ plugins {
     id("org.jetbrains.kotlinx.kover")
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     kover(project(":subproject"))
 }

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/no-dependency-jvm/subproject/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/no-dependency-jvm/subproject/build.gradle.kts
@@ -1,7 +1,3 @@
 plugins {
     kotlin("jvm")
 }
-
-repositories {
-    mavenCentral()
-}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/no-tests-jvm/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/no-tests-jvm/build.gradle.kts
@@ -3,10 +3,6 @@ plugins {
     id("org.jetbrains.kotlinx.kover")
 }
 
-repositories {
-    mavenCentral()
-}
-
 kover {
     reports {
         verify {

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/no-tests-mpp/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/no-tests-mpp/build.gradle.kts
@@ -8,10 +8,6 @@ kotlin {
     jvmToolchain(8)
 }
 
-repositories {
-    mavenCentral()
-}
-
 /*
  * Kover configs
  */

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/sourcesets-mpp/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/sourcesets-mpp/build.gradle.kts
@@ -3,10 +3,6 @@ plugins {
     id("org.jetbrains.kotlinx.kover") version "0.7.0"
 }
 
-repositories {
-    mavenCentral()
-}
-
 kover {
     variants {
         sources {

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/sourcesets/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/sourcesets/build.gradle.kts
@@ -3,10 +3,6 @@ plugins {
     id("org.jetbrains.kotlinx.kover") version "0.7.0"
 }
 
-repositories {
-    mavenCentral()
-}
-
 sourceSets.create("extra")
 
 kover {

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/commons/Paths.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/commons/Paths.kt
@@ -4,13 +4,14 @@
 
 package kotlinx.kover.gradle.plugin.commons
 
-import kotlinx.kover.gradle.plugin.tools.*
+import kotlinx.kover.features.jvm.KoverFeatures
+import kotlinx.kover.gradle.plugin.tools.CoverageToolVariant
 import java.io.File
 
 
 internal fun agentFilePath(toolVariant: CoverageToolVariant): String {
     return if (toolVariant.vendor == CoverageToolVendor.KOVER) {
-        "kover${separator}intellij-coverage-agent-${toolVariant.version}.jar"
+        "kover${separator}kover-jvm-agent-${KoverFeatures.getVersion()}.jar"
     } else {
         "kover${separator}jacoco-coverage-agent-${toolVariant.version}.jar"
     }

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverVersions.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverVersions.kt
@@ -3,6 +3,8 @@
  */
 package kotlinx.kover.gradle.plugin.dsl
 
+import kotlinx.kover.features.jvm.KoverFeatures
+
 /**
  * Stable reference point for various versions that Kover leverages.
  */
@@ -21,4 +23,10 @@ public object KoverVersions {
      * JaCoCo coverage tool version used by default.
      */
     public const val JACOCO_TOOL_DEFAULT_VERSION = "0.8.10"
+
+    /**
+     * Current version of Kover Gradle Plugin
+     */
+    public val version: String
+        get() = KoverFeatures.getVersion()
 }

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/kover/KoverOnlineInstrumentation.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/kover/KoverOnlineInstrumentation.kt
@@ -4,52 +4,8 @@
 
 package kotlinx.kover.gradle.plugin.tools.kover
 
-import kotlinx.kover.gradle.plugin.util.*
-import java.io.*
-
-/**
- * A flag to enable tracking per test coverage.
- */
-private const val TRACKING_PER_TEST = false
-
-/**
- * A flag to calculate coverage for unloaded classes.
- */
-private const val CALCULATE_FOR_UNLOADED_CLASSES = false
-
-/**
- * Use data file as initial coverage.
- *
- * `false` - to overwrite previous file content.
- */
-private const val APPEND_TO_DATA_FILE = true
-
-
-/**
- * Create hit block only for line - adds the ability to count branches
- */
-private const val LINING_ONLY_MODE = false
-
-/**
- * Enables saving the array in the candy field,
- * without it there will be an appeal to the hash table foreach method, which very slow.
- */
-private const val ENABLE_TRACING = "idea.new.tracing.coverage=true"
-
-/**
- * Disable agent logging to stdout for messages of levels `debug`, `info`, `warn`.
- */
-private const val PRINT_ONLY_ERRORS = "idea.coverage.log.level=error"
-
-/**
- * Enables ignoring constructors in classes where all methods are static.
- */
-private const val IGNORE_STATIC_CONSTRUCTORS = "coverage.ignore.private.constructor.util.class=true"
-
-/**
- * Do not count amount hits of the line, only 0 or 1 will be place into int[] - reduce byte code size
- */
-private const val DO_NOT_COUNT_HIT_AMOUNT = "idea.coverage.calculate.hits=false"
+import kotlinx.kover.gradle.plugin.util.wildcardsToRegex
+import java.io.File
 
 internal fun buildJvmAgentArgs(
     jarFile: File,
@@ -60,33 +16,17 @@ internal fun buildJvmAgentArgs(
     val argsFile = tempDir.resolve("kover-agent.args")
     argsFile.writeAgentArgs(binReportFile, excludedClasses)
 
-    return mutableListOf(
-        "-javaagent:${jarFile.canonicalPath}=${argsFile.canonicalPath}",
-        property(ENABLE_TRACING),
-        property(PRINT_ONLY_ERRORS),
-        property(IGNORE_STATIC_CONSTRUCTORS),
-        property(DO_NOT_COUNT_HIT_AMOUNT)
-    )
+    return mutableListOf("-javaagent:${jarFile.canonicalPath}=file:${argsFile.canonicalPath}")
 }
-
-private fun property(propertyDef: String) = "-D$propertyDef"
 
 private fun File.writeAgentArgs(binReportFile: File, excludedClasses: Set<String>) {
     binReportFile.parentFile.mkdirs()
     val binReportPath = binReportFile.canonicalPath
 
     printWriter().use { pw ->
-        pw.appendLine(binReportPath)
-        pw.appendLine(TRACKING_PER_TEST.toString())
-        pw.appendLine(CALCULATE_FOR_UNLOADED_CLASSES.toString())
-        pw.appendLine(APPEND_TO_DATA_FILE.toString())
-        pw.appendLine(LINING_ONLY_MODE.toString())
-
-        if (excludedClasses.isNotEmpty()) {
-            pw.appendLine("-exclude")
-            excludedClasses.forEach { e ->
-                pw.appendLine(e.wildcardsToRegex())
-            }
+        pw.append("report.file=").appendLine(binReportPath)
+        excludedClasses.forEach { e ->
+            pw.append("exclude=").appendLine(e)
         }
     }
 }

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/kover/KoverTool.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tools/kover/KoverTool.kt
@@ -4,28 +4,27 @@
 
 package kotlinx.kover.gradle.plugin.tools.kover
 
-import kotlinx.kover.gradle.plugin.commons.ArtifactContent
+import kotlinx.kover.features.jvm.KoverFeatures
 import kotlinx.kover.gradle.plugin.commons.ReportContext
-import kotlinx.kover.gradle.plugin.commons.ReportFilters
 import kotlinx.kover.gradle.plugin.commons.VerificationRule
-import kotlinx.kover.gradle.plugin.tools.*
-import org.gradle.api.*
-import org.gradle.api.file.*
-import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.Property
-import org.gradle.workers.WorkParameters
-import java.io.*
+import kotlinx.kover.gradle.plugin.tools.CoverageRequest
+import kotlinx.kover.gradle.plugin.tools.CoverageTool
+import kotlinx.kover.gradle.plugin.tools.CoverageToolVariant
+import org.gradle.api.GradleException
+import org.gradle.api.file.ArchiveOperations
+import org.gradle.api.file.FileCollection
+import java.io.File
 
 
 internal class KoverTool(override val variant: CoverageToolVariant) : CoverageTool {
-    override val jvmAgentDependency: String = "org.jetbrains.intellij.deps:intellij-coverage-agent:${variant.version}"
+    override val jvmAgentDependency: String = "org.jetbrains.kotlinx:kover-jvm-agent:${KoverFeatures.getVersion()}"
 
     override val jvmReporterDependency: String = "org.jetbrains.intellij.deps:intellij-coverage-reporter:${variant.version}"
     override val jvmReporterExtraDependency: String = "org.jetbrains.intellij.deps:intellij-coverage-reporter:${variant.version}"
 
 
     override fun findJvmAgentJar(classpath: FileCollection, archiveOperations: ArchiveOperations): File {
-        return classpath.filter { it.name.startsWith("intellij-coverage-agent") }.files.firstOrNull()
+        return classpath.filter { it.name.startsWith("kover-jvm-agent") }.files.firstOrNull()
             ?: throw GradleException("JVM instrumentation agent not found for Kover Coverage Tool")
     }
 

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/util/Versions.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/util/Versions.kt
@@ -4,20 +4,23 @@
 
 package kotlinx.kover.gradle.plugin.util
 
-internal class SemVer(private val major: Int, private val minor: Int, private val patch: Int) : Comparable<SemVer> {
+internal class SemVer(private val major: Int, private val minor: Int?, private val patch: Int?) : Comparable<SemVer> {
+    val minorSafe: Int = minor ?: 0
+    val patchSafe: Int = patch ?: 0
+
     companion object {
         /**
          * Supported formats:
-         *  - "1" -> 1.0.0
-         *  - "1.2" -> 1.2.0
-         *  - "1.2.3" -> 1.2.3
+         *  - "1"
+         *  - "1.2"
+         *  - "1.2.3"
          */
         fun ofVariableOrNull(version: String): SemVer? {
             val parts = version.substringBefore('-').split(".")
 
             val major = parts[0].toIntOrNull()?: return null
-            val minor = parts.getOrNull(1)?.toIntOrNull()?: 0
-            val patch = parts.getOrNull(2)?.toIntOrNull()?: 0
+            val minor = parts.getOrNull(1)?.toIntOrNull()
+            val patch = parts.getOrNull(2)?.toIntOrNull()
 
             return SemVer(major, minor, patch)
         }
@@ -35,10 +38,15 @@ internal class SemVer(private val major: Int, private val minor: Int, private va
         }
     }
 
+    /**
+     *  Comparison uses the substitution of the missing parts:
+     *  - 1 == 1.0.0
+     *  - 1.2 == 1.2.0
+     */
     override fun compareTo(other: SemVer): Int {
         major.compareTo(other.major).takeIf { it != 0 }?.let { return it }
-        minor.compareTo(other.minor).takeIf { it != 0 }?.let { return it }
-        return patch.compareTo(other.patch)
+        minorSafe.compareTo(other.minorSafe).takeIf { it != 0 }?.let { return it }
+        return patchSafe.compareTo(other.patchSafe)
     }
 
     override fun equals(other: Any?): Boolean {
@@ -46,10 +54,14 @@ internal class SemVer(private val major: Int, private val minor: Int, private va
         return other is SemVer && this.compareTo(other) == 0
     }
 
+    override fun toString(): String {
+        return listOfNotNull(major.toString(), minor?.toString(), patch?.toString()).joinToString(".")
+    }
+
     override fun hashCode(): Int {
         var result = major.hashCode()
-        result = 31 * result + minor.hashCode()
-        result = 31 * result + patch.hashCode()
+        result = 31 * result + minorSafe.hashCode()
+        result = 31 * result + patchSafe.hashCode()
         return result
     }
 }

--- a/kover-jvm-agent/build.gradle.kts
+++ b/kover-jvm-agent/build.gradle.kts
@@ -18,9 +18,15 @@ plugins {
     java
     id("kover-publishing-conventions")
     id("kover-fat-jar-conventions")
+    id("kover-docs-conventions")
 }
 
 extensions.configure<Kover_publishing_conventions_gradle.KoverPublicationExtension> {
+    description.set("Kover JVM instrumentation agent")
+}
+
+extensions.configure<Kover_docs_conventions_gradle.KoverDocsExtension> {
+    docsDirectory.set("jvm-agent")
     description.set("Kover JVM instrumentation agent")
 }
 

--- a/kover-jvm-agent/build.gradle.kts
+++ b/kover-jvm-agent/build.gradle.kts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    java
+    id("kover-publishing-conventions")
+    id("kover-fat-jar-conventions")
+}
+
+extensions.configure<Kover_publishing_conventions_gradle.KoverPublicationExtension> {
+    description.set("Kover JVM instrumentation agent")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_6
+    targetCompatibility = JavaVersion.VERSION_1_6
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly(libs.intellij.agent)
+    fatJar(libs.intellij.agent)
+}
+
+val targetVersion = if (project.hasProperty("releaseVersion")) {
+    project.property("releaseVersion").toString()
+} else {
+    project.version.toString()
+}
+
+tasks.jar {
+    manifest {
+        attributes(
+            "Premain-Class" to "kotlinx.kover.jvmagent.KoverJvmAgentPremain",
+            "Can-Retransform-Classes" to "true",
+            // We need to pass this parameter, because IntelliJ agent collects data in the bootstrap class loader
+            // it is not possible to use other loaders because some of them (for example, FilteredClassLoader) restrict access to agent classes
+            "Boot-Class-Path" to "${project.name}-$targetVersion.jar"
+        )
+    }
+}

--- a/kover-jvm-agent/docs/index.md
+++ b/kover-jvm-agent/docs/index.md
@@ -1,0 +1,45 @@
+# Kover JVM instrumentation agent
+
+## On the fly instrumentation
+On the fly instrumentation - modification of the bytecode of classes in order to measure coverage, that occurs when the class is loaded into the JVM.
+
+To instrument the loaded classes, it is necessary to connect a JVM agent to the Java application being launched.
+
+## Getting a readable report
+To get a readable coverage report, you need to:
+1. [Connect JVM agent on JVM start](#connecting-the-jvm-agent)
+2. Terminate the JVM application. When application finished, the binary report file will be saved
+3. Using the [Kover CLI](/cli#generating-reports), generate a human-readable report from a binary report
+
+## Connecting the JVM agent
+1. Download the latest version of the Kover JVM agent jar from [maven repository](https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kover-jvm-agent).
+2. Put JVM agent jar file in a local directory (Important! renaming a jar file is not allowed)
+3. Create a file with agent arguments, [learn more about the arguments](#kover-jvm-arguments-file)
+4. Add an argument to the java application startup command `-javaagent:<path_to_agent_jar>=file:<path_to_settings_file>`.
+   Example of an application launch command `java -jar application.jar -javaagent:/opt/kover-jvm-agent-0.7.6.jar=file:/tmp/agent.args`
+
+## Kover JVM arguments file
+The arguments file is a set of settings, each of which is written on a new line.
+Line format: `argument_name=argument_value`
+
+List of arguments:
+- `report.file` - path to the file, which will contain a binary coverage report in ic format. The file is created if it did not exist before
+- `report.append` - it is acceptable to specify true or false. if true, then if the file will be appended if the coverage is already stored in it
+- `exclude` - specify which classes do not need to be modified when loading. For such classes, the coverage will always be 0.
+  
+  It is acceptable to use `*` and `?` wildcards, `*` means any number of arbitrary characters (including no chars), `?` means one arbitrary character.
+- `exclude.regex` - specify which classes do not need to be modified when loading. For such classes, the coverage will always be 0.
+
+  It is acceptable to specify regex.
+- `include` - specify which classes will be modified when loading, all other classes will not.
+
+  It is acceptable to use `*` and `?` wildcards, `*` means any number of arbitrary characters (including no chars), `?` means one arbitrary character.
+- `include.regex` - specify which classes will be modified when loading, all other classes will not.
+
+  It is acceptable to specify regex.
+
+Example of arguments file
+```properties
+report.file=/tmp/kover-report.ic
+exclude=com.example.*
+```

--- a/kover-jvm-agent/docs/index.md
+++ b/kover-jvm-agent/docs/index.md
@@ -7,22 +7,24 @@ To instrument the loaded classes, it is necessary to connect a JVM agent to the 
 
 ## Getting a readable report
 To get a readable coverage report, you need to:
-1. [Connect JVM agent on JVM start](#connecting-the-jvm-agent)
-2. Terminate the JVM application. When application finished, the binary report file will be saved
-3. Using the [Kover CLI](/cli#generating-reports), generate a human-readable report from a binary report
+1. [Connect JVM agent on JVM start](#connecting-the-jvm-agent).
+2. Run your tests and wait until it exits. When the application is finished, the binary report file will be saved.
+3. Using the [Kover CLI](/cli#generating-reports), generate a human-readable report from a binary report.
 
 ## Connecting the JVM agent
 1. Download the latest version of the Kover JVM agent jar from [maven repository](https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kover-jvm-agent).
-2. Put JVM agent jar file in a local directory (Important! renaming a jar file is not allowed)
-3. Create a file with agent arguments, [learn more about the arguments](#kover-jvm-arguments-file)
+2. Put JVM agent jar file in a local directory (Important! renaming a jar file is not allowed).
+3. Create a file with agent arguments, [learn more about the arguments](#kover-jvm-arguments-file).
 4. Add an argument to the java application startup command `-javaagent:<path_to_agent_jar>=file:<path_to_settings_file>`.
-   Example of an application launch command `java -jar application.jar -javaagent:/opt/kover-jvm-agent-0.7.6.jar=file:/tmp/agent.args`
+   Example of an application launch command `java -jar application.jar -javaagent:/opt/kover-jvm-agent-0.7.6.jar=file:/tmp/agent.args`.
 
 ## Kover JVM arguments file
 The arguments file is a set of settings, each of which is written on a new line.
 Line format: `argument_name=argument_value`
 
-List of arguments:
+`report.file` argument is required, while the rest are optional.
+
+List of all available arguments:
 - `report.file` - path to the file, which will contain a binary coverage report in ic format. The file is created if it did not exist before
 - `report.append` - it is acceptable to specify true or false. if true, then if the file will be appended if the coverage is already stored in it
 - `exclude` - specify which classes do not need to be modified when loading. For such classes, the coverage will always be 0.
@@ -38,7 +40,9 @@ List of arguments:
 
   It is acceptable to specify regex.
 
-Example of arguments file
+It is possible to use `exclude` and `exclude.regex` at the same time, also `include` and `include.regex`. 
+
+Example of arguments file:
 ```properties
 report.file=/tmp/kover-report.ic
 exclude=com.example.*

--- a/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/IntellijIntegration.java
+++ b/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/IntellijIntegration.java
@@ -6,8 +6,6 @@ import java.lang.instrument.Instrumentation;
 import java.util.ArrayList;
 import java.util.List;
 
-import static kotlinx.kover.jvmagent.ParseUtils.isBoolean;
-
 public class IntellijIntegration {
     /**
      * A flag to enable tracking per test coverage.
@@ -22,7 +20,7 @@ public class IntellijIntegration {
     /**
      * Create hit block only for line, false adds the ability to count branches
      */
-    private static final boolean LINING_ONLY_MODE = false;
+    private static final boolean LINES_ONLY_MODE = false;
 
     private IntellijIntegration() {
         // no-op
@@ -41,7 +39,7 @@ public class IntellijIntegration {
         // Disable agent logging to stdout for messages of levels `debug`, `info`, `warn`.
         System.setProperty("idea.coverage.log.level", "error");
 
-        // Enables saving the array in the candy field,
+        // Enables saving the array in the ConDy field,
         // without it there will be an appeal to the hash table foreach method, which very slow.
         System.setProperty("idea.new.tracing.coverage", "true");
 
@@ -83,7 +81,7 @@ public class IntellijIntegration {
         args.add(Boolean.toString(TRACKING_PER_TEST));
         args.add(Boolean.toString(CALCULATE_FOR_UNLOADED_CLASSES));
         args.add(Boolean.toString(settings.appendToReportFile));
-        args.add(Boolean.toString(LINING_ONLY_MODE));
+        args.add(Boolean.toString(LINES_ONLY_MODE));
 
         args.addAll(settings.inclusions);
 
@@ -98,7 +96,7 @@ public class IntellijIntegration {
     private static String joinIntellijArgs(List<String> args) {
         StringBuilder builder = new StringBuilder();
         for (String arg : args) {
-            if (isBoolean(arg)) {
+            if (KoverJvmAgentPremain.isBoolean(arg)) {
                 builder.append(arg);
             } else {
                 builder.append('"');

--- a/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/IntellijIntegration.java
+++ b/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/IntellijIntegration.java
@@ -1,0 +1,112 @@
+package kotlinx.kover.jvmagent;
+
+import com.intellij.rt.coverage.main.CoveragePremain;
+
+import java.lang.instrument.Instrumentation;
+import java.util.ArrayList;
+import java.util.List;
+
+import static kotlinx.kover.jvmagent.ParseUtils.isBoolean;
+
+public class IntellijIntegration {
+    /**
+     * A flag to enable tracking per test coverage.
+     */
+    private static final boolean TRACKING_PER_TEST = false;
+
+    /**
+     * A flag to calculate coverage for unloaded classes.
+     */
+    private static final boolean CALCULATE_FOR_UNLOADED_CLASSES = false;
+
+    /**
+     * Create hit block only for line, false adds the ability to count branches
+     */
+    private static final boolean LINING_ONLY_MODE = false;
+
+    private IntellijIntegration() {
+        // no-op
+    }
+
+    public static void callPremain(KoverAgentSettings settings, Instrumentation instrumentation) throws Exception {
+        setIntellijSystemProperties();
+        String intelliJArgsString = joinIntellijArgs(createIntellijArgs(settings));
+
+        CoveragePremain.premain(intelliJArgsString, instrumentation);
+    }
+
+    private static void setIntellijSystemProperties() {
+        System.setProperty("idea.coverage.use.system.classloader", "true");
+
+        // Disable agent logging to stdout for messages of levels `debug`, `info`, `warn`.
+        System.setProperty("idea.coverage.log.level", "error");
+
+        // Enables saving the array in the candy field,
+        // without it there will be an appeal to the hash table foreach method, which very slow.
+        System.setProperty("idea.new.tracing.coverage", "true");
+
+        // Enables ignoring constructors in classes where all methods are static.
+        System.setProperty("coverage.ignore.private.constructor.util.class", "true");
+
+        // Do not count amount hits of the line, only 0 or 1 will be place into int[] - reduce byte code size
+        System.setProperty("idea.coverage.calculate.hits", "false");
+    }
+
+    /**
+     *
+     * IntelliJ agent arguments format:
+     * [0] data file to save coverage result
+     * [1] a flag to enable tracking per test coverage
+     * [2] a flag to calculate coverage for unloaded classes
+     * [3] a flag to use data file as initial coverage, also use it if several parallel processes are to write into one file
+     * [4] a flag to run line coverage or branch coverage otherwise
+     * // optional smap block
+     * [5] optional: true
+     * [6] smap file path
+     * // end of optional smap
+     * // optional includes block, until first line started with '-' or eof
+     * [N+1] inclusion pattern
+     * [N+i] ...
+     * // optional excludes block, until first line started with '-' or eof
+     * [N]-exclude
+     * [N+1] exclusion pattern
+     * [N+i] ...
+     * // optional excludes annotation block, until first line started with '-' or eof
+     * [N]-excludeAnnotations
+     * [N+1] annotation exclusion pattern
+     * [N+i] ...
+     *
+     */
+    private static List<String> createIntellijArgs(KoverAgentSettings settings) {
+        ArrayList<String> args = new ArrayList<String>();
+        args.add(settings.reportFilePath);
+        args.add(Boolean.toString(TRACKING_PER_TEST));
+        args.add(Boolean.toString(CALCULATE_FOR_UNLOADED_CLASSES));
+        args.add(Boolean.toString(settings.appendToReportFile));
+        args.add(Boolean.toString(LINING_ONLY_MODE));
+
+        args.addAll(settings.inclusions);
+
+        if (!settings.exclusions.isEmpty()) {
+            args.add("-exclude");
+            args.addAll(settings.exclusions);
+        }
+
+        return args;
+    }
+
+    private static String joinIntellijArgs(List<String> args) {
+        StringBuilder builder = new StringBuilder();
+        for (String arg : args) {
+            if (isBoolean(arg)) {
+                builder.append(arg);
+            } else {
+                builder.append('"');
+                builder.append(arg);
+                builder.append('"');
+            }
+            builder.append(',');
+        }
+        return builder.toString();
+    }
+}

--- a/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/KoverAgentSettings.java
+++ b/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/KoverAgentSettings.java
@@ -1,0 +1,11 @@
+package kotlinx.kover.jvmagent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class KoverAgentSettings {
+    public String reportFilePath = null;
+    public boolean appendToReportFile = true;
+    public List<String> inclusions = new ArrayList<String>();
+    public List<String> exclusions = new ArrayList<String>();
+}

--- a/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/KoverAgentSettings.java
+++ b/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/KoverAgentSettings.java
@@ -8,4 +8,14 @@ public class KoverAgentSettings {
     public boolean appendToReportFile = true;
     public List<String> inclusions = new ArrayList<String>();
     public List<String> exclusions = new ArrayList<String>();
+
+    @Override
+    public String toString() {
+        return "KoverAgentSettings{" +
+                "reportFilePath='" + reportFilePath + '\'' +
+                ", appendToReportFile=" + appendToReportFile +
+                ", inclusions=" + inclusions +
+                ", exclusions=" + exclusions +
+                '}';
+    }
 }

--- a/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/KoverJvmAgentPremain.java
+++ b/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/KoverJvmAgentPremain.java
@@ -9,24 +9,24 @@ import java.util.List;
 public class KoverJvmAgentPremain {
 
     private static final String FILE_PREFIX_IN_ARGS = "file:";
-    private static final String FILE_PATH_ATTRIBUTE = "report.file=";
-    private static final String APPEND_ATTRIBUTE = "report.append=";
-    private static final String EXCLUDE_WITH_WILDCARDS_ATTRIBUTE = "exclude=";
-    private static final String EXCLUDE_WITH_REGEX_ATTRIBUTE = "exclude.regex=";
-    private static final String INCLUDE_WITH_WILDCARDS_ATTRIBUTE = "include=";
-    private static final String INCLUDE_WITH_REGEX_ATTRIBUTE = "include.regex=";
+    private static final String FILE_PATH_ARGUMENT = "report.file=";
+    private static final String APPEND_ARGUMENT = "report.append=";
+    private static final String EXCLUDE_WITH_WILDCARDS_ARGUMENT = "exclude=";
+    private static final String EXCLUDE_WITH_REGEX_ARGUMENT = "exclude.regex=";
+    private static final String INCLUDE_WITH_WILDCARDS_ARGUMENT = "include=";
+    private static final String INCLUDE_WITH_REGEX_ARGUMENT = "include.regex=";
 
     private static final String regexMetacharacters = "<([{\\^-=$!|]})+.>";
 
     private static final HashSet<Character> regexMetacharactersSet = new HashSet<Character>();
 
-    private static final List<String> attributes = Arrays.asList(
-            FILE_PATH_ATTRIBUTE,
-            APPEND_ATTRIBUTE,
-            EXCLUDE_WITH_WILDCARDS_ATTRIBUTE,
-            EXCLUDE_WITH_REGEX_ATTRIBUTE,
-            INCLUDE_WITH_WILDCARDS_ATTRIBUTE,
-            INCLUDE_WITH_REGEX_ATTRIBUTE
+    private static final List<String> arguments = Arrays.asList(
+            FILE_PATH_ARGUMENT,
+            APPEND_ARGUMENT,
+            EXCLUDE_WITH_WILDCARDS_ARGUMENT,
+            EXCLUDE_WITH_REGEX_ARGUMENT,
+            INCLUDE_WITH_WILDCARDS_ARGUMENT,
+            INCLUDE_WITH_REGEX_ARGUMENT
     );
 
     static {
@@ -61,29 +61,29 @@ public class KoverJvmAgentPremain {
 
             String line = reader.readLine();
             while (line != null ) {
-                if (line.startsWith(FILE_PATH_ATTRIBUTE)) {
-                    settings.reportFilePath = line.substring(FILE_PATH_ATTRIBUTE.length());
-                } else if (line.startsWith(EXCLUDE_WITH_WILDCARDS_ATTRIBUTE)) {
-                    String wildcards = line.substring(EXCLUDE_WITH_WILDCARDS_ATTRIBUTE.length());
+                if (line.startsWith(FILE_PATH_ARGUMENT)) {
+                    settings.reportFilePath = line.substring(FILE_PATH_ARGUMENT.length());
+                } else if (line.startsWith(EXCLUDE_WITH_WILDCARDS_ARGUMENT)) {
+                    String wildcards = line.substring(EXCLUDE_WITH_WILDCARDS_ARGUMENT.length());
                     settings.exclusions.add(wildcardsToRegex(wildcards));
-                } else if (line.startsWith(EXCLUDE_WITH_REGEX_ATTRIBUTE)) {
-                    settings.exclusions.add(line.substring(EXCLUDE_WITH_REGEX_ATTRIBUTE.length()));
-                } else if (line.startsWith(INCLUDE_WITH_WILDCARDS_ATTRIBUTE)) {
-                    String wildcards = line.substring(INCLUDE_WITH_WILDCARDS_ATTRIBUTE.length());
+                } else if (line.startsWith(EXCLUDE_WITH_REGEX_ARGUMENT)) {
+                    settings.exclusions.add(line.substring(EXCLUDE_WITH_REGEX_ARGUMENT.length()));
+                } else if (line.startsWith(INCLUDE_WITH_WILDCARDS_ARGUMENT)) {
+                    String wildcards = line.substring(INCLUDE_WITH_WILDCARDS_ARGUMENT.length());
                     settings.exclusions.add(wildcardsToRegex(wildcards));
-                } else if (line.startsWith(INCLUDE_WITH_REGEX_ATTRIBUTE)) {
-                    settings.exclusions.add(line.substring(INCLUDE_WITH_REGEX_ATTRIBUTE.length()));
-                } else if (line.startsWith(APPEND_ATTRIBUTE)) {
-                    String value = line.substring(APPEND_ATTRIBUTE.length());
+                } else if (line.startsWith(INCLUDE_WITH_REGEX_ARGUMENT)) {
+                    settings.exclusions.add(line.substring(INCLUDE_WITH_REGEX_ARGUMENT.length()));
+                } else if (line.startsWith(APPEND_ARGUMENT)) {
+                    String value = line.substring(APPEND_ARGUMENT.length());
                     if (!isBoolean(value)) {
-                        throw new IllegalArgumentException("Incorrect value for argument " + APPEND_ATTRIBUTE + " in Kover JVM agent arguments file, expected true or false");
+                        throw new IllegalArgumentException("Incorrect value for argument " + APPEND_ARGUMENT + " in Kover JVM agent arguments file, expected true or false");
                     }
                     settings.appendToReportFile = Boolean.parseBoolean(value);
                 } else if (line.length() == 0) {
                     // skip empty line
                 } else {
                     throw new IllegalArgumentException("Unrecognized line in Kover arguments file: " + line
-                            + ". Line must start with one of prefixes: " + attributes);
+                            + ". Line must start with one of prefixes: " + arguments);
                 }
                 line = reader.readLine();
             }
@@ -99,7 +99,7 @@ public class KoverJvmAgentPremain {
         }
 
         if (settings.reportFilePath == null) {
-            throw new IllegalArgumentException("Path to the report file is required, add " + FILE_PATH_ATTRIBUTE + " attribute to the args file");
+            throw new IllegalArgumentException("Path to the report file is required, add " + FILE_PATH_ARGUMENT + " argument to the args file");
         }
 
         return settings;

--- a/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/KoverJvmAgentPremain.java
+++ b/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/KoverJvmAgentPremain.java
@@ -1,0 +1,119 @@
+package kotlinx.kover.jvmagent;
+
+import java.io.*;
+import java.lang.instrument.Instrumentation;
+import java.util.HashSet;
+
+import static kotlinx.kover.jvmagent.ParseUtils.isBoolean;
+
+public class KoverJvmAgentPremain {
+
+    private static final String FILE_PREFIX_IN_ARGS = "file:";
+    private static final String FILE_PATH_ATTRIBUTE = "report.file=";
+    private static final String APPEND_ATTRIBUTE = "report.append=";
+    private static final String EXCLUDE_WITH_WILDCARDS_ATTRIBUTE = "exclude=";
+    private static final String EXCLUDE_WITH_REGEX_ATTRIBUTE = "exclude.regex=";
+    private static final String INCLUDE_WITH_WILDCARDS_ATTRIBUTE = "include=";
+    private static final String INCLUDE_WITH_REGEX_ATTRIBUTE = "include.regex=";
+
+    private static final String regexMetacharacters = "<([{\\^-=$!|]})+.>";
+
+    private static final HashSet<Character> regexMetacharactersSet = new HashSet<Character>();
+
+    static {
+        for (int i = 0; i < regexMetacharacters.length(); i++) {
+            char c = regexMetacharacters.charAt(i);
+            regexMetacharactersSet.add(c);
+        }
+    }
+
+    public static void premain(String argsString, Instrumentation instrumentation) throws Exception {
+        KoverAgentSettings settings = readSettingsFromFile(extractArgsFile(argsString));
+        IntellijIntegration.callPremain(settings, instrumentation);
+    }
+
+    private static File extractArgsFile(String args) {
+        if (!args.startsWith(FILE_PREFIX_IN_ARGS)) {
+            throw new IllegalArgumentException("Incorrect arguments format for Kover JVM agent, arguments are expected to start with " + FILE_PREFIX_IN_ARGS);
+        }
+        return new File(args.substring(FILE_PREFIX_IN_ARGS.length()));
+    }
+
+
+    private static KoverAgentSettings readSettingsFromFile(File file) throws IOException {
+        KoverAgentSettings settings = new KoverAgentSettings();
+
+        BufferedReader reader = null;
+        try {
+            reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+
+            String line = reader.readLine();
+            while (line != null ) {
+                if (line.startsWith(FILE_PATH_ATTRIBUTE)) {
+                    settings.reportFilePath = line.substring(FILE_PATH_ATTRIBUTE.length());
+                } else if (line.startsWith(EXCLUDE_WITH_WILDCARDS_ATTRIBUTE)) {
+                    String wildcards = line.substring(EXCLUDE_WITH_WILDCARDS_ATTRIBUTE.length());
+                    settings.exclusions.add(wildcardsToRegex(wildcards));
+                } else if (line.startsWith(EXCLUDE_WITH_REGEX_ATTRIBUTE)) {
+                    settings.exclusions.add(line.substring(EXCLUDE_WITH_REGEX_ATTRIBUTE.length()));
+                } else if (line.startsWith(INCLUDE_WITH_WILDCARDS_ATTRIBUTE)) {
+                    String wildcards = line.substring(INCLUDE_WITH_WILDCARDS_ATTRIBUTE.length());
+                    settings.exclusions.add(wildcardsToRegex(wildcards));
+                } else if (line.startsWith(INCLUDE_WITH_REGEX_ATTRIBUTE)) {
+                    settings.exclusions.add(line.substring(INCLUDE_WITH_REGEX_ATTRIBUTE.length()));
+                } else if (line.startsWith(APPEND_ATTRIBUTE)) {
+                    String value = line.substring(APPEND_ATTRIBUTE.length());
+                    if (!isBoolean(value)) {
+                        throw new IllegalArgumentException("Incorrect value for argument " + APPEND_ATTRIBUTE + " in Kover JVM agent arguments file, expected true or false");
+                    }
+                    settings.appendToReportFile = Boolean.parseBoolean(value);
+                } else if (line.length() == 0) {
+                    // skip empty line
+                } else {
+                    throw new IllegalArgumentException("Unrecognized line in Kover arguments file: " + line);
+                }
+                line = reader.readLine();
+            }
+
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (IOException ignored) {
+                    // no-op
+                }
+            }
+        }
+
+        if (settings.reportFilePath == null) {
+            throw new IllegalArgumentException("Path to the report file is required, add " + FILE_PATH_ATTRIBUTE + " attribute to the args file");
+        }
+
+        return settings;
+    }
+
+    /**
+     * Replaces characters `*` or `.` to `.*`, `#` to `[^.]*` and `?` to `.` regexp characters.
+     */
+    private static String wildcardsToRegex(String value) {
+        // in most cases, the characters `*` or `.` will be present therefore, we increase the capacity in advance
+        final StringBuilder builder = new StringBuilder(value.length() * 2);
+
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (regexMetacharactersSet.contains(c)) {
+                builder.append('\\').append(c);
+            } else if (c == '*') {
+                builder.append(".*");
+            } else if (c == '?') {
+                builder.append('.');
+            } else if (c == '#') {
+                builder.append("[^.]*");
+            } else {
+                builder.append(c);
+            }
+        }
+        return builder.toString();
+    }
+
+}

--- a/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/KoverJvmAgentPremain.java
+++ b/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/KoverJvmAgentPremain.java
@@ -2,9 +2,9 @@ package kotlinx.kover.jvmagent;
 
 import java.io.*;
 import java.lang.instrument.Instrumentation;
+import java.util.Arrays;
 import java.util.HashSet;
-
-import static kotlinx.kover.jvmagent.ParseUtils.isBoolean;
+import java.util.List;
 
 public class KoverJvmAgentPremain {
 
@@ -19,6 +19,15 @@ public class KoverJvmAgentPremain {
     private static final String regexMetacharacters = "<([{\\^-=$!|]})+.>";
 
     private static final HashSet<Character> regexMetacharactersSet = new HashSet<Character>();
+
+    private static final List<String> attributes = Arrays.asList(
+            FILE_PATH_ATTRIBUTE,
+            APPEND_ATTRIBUTE,
+            EXCLUDE_WITH_WILDCARDS_ATTRIBUTE,
+            EXCLUDE_WITH_REGEX_ATTRIBUTE,
+            INCLUDE_WITH_WILDCARDS_ATTRIBUTE,
+            INCLUDE_WITH_REGEX_ATTRIBUTE
+    );
 
     static {
         for (int i = 0; i < regexMetacharacters.length(); i++) {
@@ -39,6 +48,9 @@ public class KoverJvmAgentPremain {
         return new File(args.substring(FILE_PREFIX_IN_ARGS.length()));
     }
 
+    public static boolean isBoolean(String value) {
+        return "true".equals(value) || "false".equals(value);
+    }
 
     private static KoverAgentSettings readSettingsFromFile(File file) throws IOException {
         KoverAgentSettings settings = new KoverAgentSettings();
@@ -70,7 +82,8 @@ public class KoverJvmAgentPremain {
                 } else if (line.length() == 0) {
                     // skip empty line
                 } else {
-                    throw new IllegalArgumentException("Unrecognized line in Kover arguments file: " + line);
+                    throw new IllegalArgumentException("Unrecognized line in Kover arguments file: " + line
+                            + ". Line must start with one of prefixes: " + attributes);
                 }
                 line = reader.readLine();
             }

--- a/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/ParseUtils.java
+++ b/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/ParseUtils.java
@@ -1,9 +1,0 @@
-package kotlinx.kover.jvmagent;
-
-public class ParseUtils {
-    private ParseUtils() {
-        // no-op
-    }
-
-
-}

--- a/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/ParseUtils.java
+++ b/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/ParseUtils.java
@@ -1,0 +1,11 @@
+package kotlinx.kover.jvmagent;
+
+public class ParseUtils {
+    private ParseUtils() {
+        // no-op
+    }
+
+    public static boolean isBoolean(String value) {
+        return "true".equals(value) || "false".equals(value);
+    }
+}

--- a/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/ParseUtils.java
+++ b/kover-jvm-agent/src/main/java/kotlinx/kover/jvmagent/ParseUtils.java
@@ -5,7 +5,5 @@ public class ParseUtils {
         // no-op
     }
 
-    public static boolean isBoolean(String value) {
-        return "true".equals(value) || "false".equals(value);
-    }
+
 }

--- a/kover-offline-runtime/build.gradle.kts
+++ b/kover-offline-runtime/build.gradle.kts
@@ -17,6 +17,7 @@
 plugins {
     java
     id("kover-publishing-conventions")
+    id("kover-docs-conventions")
 }
 
 extensions.configure<Kover_publishing_conventions_gradle.KoverPublicationExtension> {
@@ -51,16 +52,8 @@ tasks.jar {
     }
 }
 
-tasks.register("releaseDocs") {
-    val dirName = "offline-instrumentation"
-    val description = "Kover offline instrumentation"
-    val sourceDir = projectDir.resolve("docs")
-    val resultDir = rootDir.resolve("docs/$dirName")
-    val mainIndexFile = rootDir.resolve("docs/index.md")
-
-    doLast {
-        resultDir.mkdirs()
-        sourceDir.copyRecursively(resultDir)
-        mainIndexFile.appendText("- [$description]($dirName)\n")
-    }
+extensions.configure<Kover_docs_conventions_gradle.KoverDocsExtension> {
+    docsDirectory.set("offline-instrumentation")
+    description.set("Kover offline instrumentation")
+    callDokkaHtml.set(true)
 }

--- a/kover-offline-runtime/build.gradle.kts
+++ b/kover-offline-runtime/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     java
     id("kover-publishing-conventions")
     id("kover-docs-conventions")
+    id("kover-fat-jar-conventions")
 }
 
 extensions.configure<Kover_publishing_conventions_gradle.KoverPublicationExtension> {
@@ -33,23 +34,9 @@ repositories {
     mavenCentral()
 }
 
-val fatJarDependency = "fatJar"
-val fatJarConfiguration = configurations.create(fatJarDependency)
-
 dependencies {
     compileOnly(libs.intellij.offline)
-    fatJarConfiguration(libs.intellij.offline)
-}
-
-tasks.jar {
-    from(
-        fatJarConfiguration.map { if (it.isDirectory) it else zipTree(it) }
-    ) {
-        exclude("OSGI-OPT/**")
-        exclude("META-INF/**")
-        exclude("LICENSE")
-        exclude("classpath.index")
-    }
+    fatJar(libs.intellij.offline)
 }
 
 extensions.configure<Kover_docs_conventions_gradle.KoverDocsExtension> {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,10 +6,6 @@ pluginManagement {
     }
 }
 
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.7.0")
-}
-
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,3 @@
-rootProject.name = "kover"
-
 pluginManagement {
     includeBuild("build-logic")
 
@@ -8,12 +6,19 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.7.0")
+}
+
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs")
     }
 }
 
+rootProject.name = "kover"
+
+include(":kover-jvm-agent")
 include(":kover-features-jvm")
 include(":kover-gradle-plugin")
 include(":kover-cli")


### PR DESCRIPTION
User can use the JVM agent separately, with the name kover and without mentioning IntelliJ, as well as reduce the number of parameters and properties required to transfer to the agent.

Now Kover Gradle Plugin uses kover-jvm-agent with the same version. To do this, the transfer of staging repositories was added to the functional tests. The common logic of publishing was also extracted into a separate convention plugin.

Resolves #464