### PR TITLE
Changed log level for print coverage task

### DIFF
--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/LoggingTaskTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/LoggingTaskTests.kt
@@ -10,6 +10,7 @@ import kotlinx.kover.gradle.plugin.dsl.GroupingEntityType
 import kotlinx.kover.gradle.plugin.dsl.CoverageUnit
 import kotlinx.kover.gradle.plugin.test.functional.framework.configurator.BuildConfigurator
 import kotlinx.kover.gradle.plugin.test.functional.framework.starter.GeneratedTest
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 internal class LoggingTaskTests {
@@ -153,6 +154,35 @@ internal class LoggingTaskTests {
                     this
                 )
             }
+        }
+    }
+
+
+    /**
+     * Check that coverage log is printed even if log level strictly limited (e.g. warn or quiet).
+     */
+    @GeneratedTest
+    fun BuildConfigurator.testLogLevel() {
+        val headerText = "MY HEADER"
+        addProjectWithKover {
+            sourcesFrom("simple")
+
+            kover {
+                reports {
+                    total {
+                        log {
+                            header.set(headerText)
+                        }
+                    }
+                }
+            }
+        }
+
+        run(":koverLog", "--quiet") {
+            assertContains(output, headerText)
+        }
+        run(":koverLog", "--warn") {
+            assertContains(output, headerText)
         }
     }
 

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/services/KoverPrintLogTask.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/services/KoverPrintLogTask.kt
@@ -5,9 +5,11 @@
 package kotlinx.kover.gradle.plugin.tasks.services
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.*
-import org.gradle.api.tasks.*
-import javax.inject.*
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
 
 internal abstract class KoverPrintLogTask : DefaultTask() {
     @get:InputFile
@@ -16,6 +18,7 @@ internal abstract class KoverPrintLogTask : DefaultTask() {
 
     @TaskAction
     fun printToLog() {
-        logger.lifecycle(fileWithMessage.asFile.get().readText())
+        // use QUIET to always print coverage, regardless of the build log level
+        logger.quiet(fileWithMessage.asFile.get().readText())
     }
 }


### PR DESCRIPTION
At the moment, the coverage was printed with the `lifecycle` level. However, if user limit the logs to the `--warn` level, the coverage stops printing. 
Now coverage is printed with the quite level, thanks to this it is printed even with the limitations of `--warn` and `--quiet`.

Fixes #557