### PR TITLE
Added overload for functions of KoverVariantCreateConfig

### DIFF
--- a/kover-gradle-plugin/api/kover-gradle-plugin.api
+++ b/kover-gradle-plugin/api/kover-gradle-plugin.api
@@ -211,9 +211,13 @@ public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverVariantConf
 }
 
 public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverVariantCreateConfig : kotlinx/kover/gradle/plugin/dsl/KoverVariantConfig {
+	public abstract fun add (Ljava/lang/Iterable;Z)V
 	public abstract fun add ([Ljava/lang/String;Z)V
+	public static synthetic fun add$default (Lkotlinx/kover/gradle/plugin/dsl/KoverVariantCreateConfig;Ljava/lang/Iterable;ZILjava/lang/Object;)V
 	public static synthetic fun add$default (Lkotlinx/kover/gradle/plugin/dsl/KoverVariantCreateConfig;[Ljava/lang/String;ZILjava/lang/Object;)V
+	public abstract fun addWithDependencies (Ljava/lang/Iterable;Z)V
 	public abstract fun addWithDependencies ([Ljava/lang/String;Z)V
+	public static synthetic fun addWithDependencies$default (Lkotlinx/kover/gradle/plugin/dsl/KoverVariantCreateConfig;Ljava/lang/Iterable;ZILjava/lang/Object;)V
 	public static synthetic fun addWithDependencies$default (Lkotlinx/kover/gradle/plugin/dsl/KoverVariantCreateConfig;[Ljava/lang/String;ZILjava/lang/Object;)V
 }
 

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/KoverMerge.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/KoverMerge.kt
@@ -114,6 +114,9 @@ private fun KoverVariantCreateConfig.wrap(project: Project): KoverMergingVariant
         override fun sources(block: Action<KoverVariantSources>) = this@wrap.sources(block)
         override fun add(vararg variantNames: String, optional: Boolean) = this@wrap.add(*variantNames, optional = optional)
         override fun addWithDependencies(vararg variantNames: String, optional: Boolean) = this@wrap.addWithDependencies(*variantNames, optional = optional)
+        override fun add(variantNames: Iterable<String>, optional: Boolean) = this@wrap.add(variantNames, optional = optional)
+        override fun addWithDependencies(variantNames: Iterable<String>, optional: Boolean) = this@wrap.addWithDependencies(variantNames, optional = optional)
+
         override val project: Project = project
     }
 }

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverVariantConfig.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverVariantConfig.kt
@@ -216,4 +216,21 @@ public interface KoverVariantCreateConfig: KoverVariantConfig {
      * If [optional] is `true` and a variant with given name is not found in the current project - in this case, the variant will not be searched even in dependencies.
      */
     public fun addWithDependencies(vararg variantNames: String, optional: Boolean = false)
+    /**
+     * Add to created variant classes, tests and instrumented classes from report variant with name [variantNames].
+     * This variant is taken only from the current project.
+     *
+     * If [optional] is `false` and a variant with given name is not found in the current project, an error [KoverIllegalConfigException] is thrown.
+     */
+    public fun add(variantNames: Iterable<String>, optional: Boolean = false)
+
+    /**
+     * Add to created variant classes, tests and instrumented classes from report variant with name [variantNames].
+     * This variant is taken from the current project and all `kover(project("name"))` dependency projects.
+     *
+     * If [optional] is `false` and a variant with given name is not found in the current project, an error [KoverIllegalConfigException] is thrown.
+     *
+     * If [optional] is `true` and a variant with given name is not found in the current project - in this case, the variant will not be searched even in dependencies.
+     */
+    public fun addWithDependencies(variantNames: Iterable<String>, optional: Boolean = false)
 }

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverVariantConfig.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverVariantConfig.kt
@@ -226,7 +226,7 @@ public interface KoverVariantCreateConfig: KoverVariantConfig {
 
     /**
      * Add to created variant classes, tests and instrumented classes from report variant with name [variantNames].
-     * This variant is taken from the current project and all `kover(project("name"))` dependency projects.
+     * These variants are taken from the current project and all `kover(project("name"))` dependency projects.
      *
      * If [optional] is `false` and a variant with given name is not found in the current project, an error [KoverIllegalConfigException] is thrown.
      *

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverVariantConfig.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverVariantConfig.kt
@@ -218,7 +218,7 @@ public interface KoverVariantCreateConfig: KoverVariantConfig {
     public fun addWithDependencies(vararg variantNames: String, optional: Boolean = false)
     /**
      * Add to created variant classes, tests and instrumented classes from report variant with name [variantNames].
-     * This variant is taken only from the current project.
+     * These variants are taken only from the current project.
      *
      * If [optional] is `false` and a variant with given name is not found in the current project, an error [KoverIllegalConfigException] is thrown.
      */

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/internal/VariantsImpl.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/internal/VariantsImpl.kt
@@ -93,12 +93,20 @@ internal abstract class KoverVariantCreateConfigImpl @Inject constructor(private
     internal val variantsByName: MutableMap<String, MergingOptionality> = mutableMapOf()
 
     override fun add(vararg variantNames: String, optional: Boolean) {
+        add(listOf(*variantNames), optional)
+    }
+
+    override fun addWithDependencies(vararg variantNames: String, optional: Boolean) {
+        addWithDependencies(listOf(*variantNames), optional)
+    }
+
+    override fun add(variantNames: Iterable<String>, optional: Boolean) {
         for (addedVariantName in variantNames) {
             addByName(addedVariantName, variantName, optional, withDependencies = false)
         }
     }
 
-    override fun addWithDependencies(vararg variantNames: String, optional: Boolean) {
+    override fun addWithDependencies(variantNames: Iterable<String>, optional: Boolean) {
         for (addedVariantName in variantNames) {
             addByName(addedVariantName, variantName, optional, withDependencies = true)
         }


### PR DESCRIPTION
Previous versions of the functions had vararg parameters, this is not always convenient if the List is presented when or Groovy is used.

Relates #570