### PR TITLE
Expose reportDir property in KoverHtmlReport interface

### DIFF
--- a/kover-gradle-plugin/api/kover-gradle-plugin.api
+++ b/kover-gradle-plugin/api/kover-gradle-plugin.api
@@ -304,6 +304,7 @@ public abstract interface class kotlinx/kover/gradle/plugin/dsl/tasks/KoverBinar
 }
 
 public abstract interface class kotlinx/kover/gradle/plugin/dsl/tasks/KoverHtmlReport : kotlinx/kover/gradle/plugin/dsl/tasks/KoverReport {
+	public abstract fun getReportDir ()Lorg/gradle/api/provider/Provider;
 }
 
 public abstract interface class kotlinx/kover/gradle/plugin/dsl/tasks/KoverLogReport : kotlinx/kover/gradle/plugin/dsl/tasks/KoverReport {

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/TaskInterfacesTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/TaskInterfacesTests.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2023 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+package kotlinx.kover.gradle.plugin.test.functional.cases
+
+import kotlinx.kover.gradle.plugin.test.functional.framework.runner.generateBuild
+import kotlinx.kover.gradle.plugin.test.functional.framework.runner.runWithParams
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+internal class TaskInterfacesTests {
+
+    @Test
+    fun testDefaultHtmlDir() {
+        val build = generateBuild { dir ->
+            dir.resolve("settings.gradle.kts").createNewFile()
+
+            dir.resolve("build.gradle.kts").writeText(
+                """
+                import kotlinx.kover.gradle.plugin.dsl.tasks.KoverHtmlReport
+                
+                plugins {
+                    kotlin("jvm") version "1.9.22"
+                    id("org.jetbrains.kotlinx.kover")
+                }
+                
+                tasks.register("checkDir") {
+                    doFirst {
+                        val task = tasks.withType<KoverHtmlReport>().matching { it.name == "koverHtmlReport" }.first()
+                        if (task.reportDir.get().asFile != layout.buildDirectory.dir("reports/kover/html").get().asFile) {
+                            throw Exception("Default directory differ, expect ${'$'}{layout.buildDirectory.dir("reports/kover/html").get().asFile} actual ${'$'}{task.reportDir.get().asFile}")
+                        }
+                    }
+                }
+            """.trimIndent()
+            )
+        }.generate()
+
+        val result = build.runWithParams("checkDir")
+        assertTrue(result.isSuccessful)
+    }
+
+    @Test
+    fun testCustomHtmlDir() {
+        val build = generateBuild { dir ->
+            dir.resolve("settings.gradle.kts").createNewFile()
+
+            dir.resolve("build.gradle.kts").writeText(
+                """
+                import kotlinx.kover.gradle.plugin.dsl.tasks.KoverHtmlReport
+                
+                plugins {
+                    kotlin("jvm") version "1.9.22"
+                    id("org.jetbrains.kotlinx.kover")
+                }
+                
+                kover {
+                    reports {
+                        total {
+                            html {
+                                htmlDir.set(layout.buildDirectory.dir("customHtmlReport"))
+                            }
+                        }
+                    }
+                }
+                
+                tasks.register("checkDir") {
+                    doFirst {
+                        val task = tasks.withType<KoverHtmlReport>().matching { it.name == "koverHtmlReport" }.first()
+                        if (task.reportDir.get().asFile != layout.buildDirectory.dir("customHtmlReport").get().asFile) {
+                            throw Exception("Custom directory differ, expect ${'$'}{layout.buildDirectory.dir("customHtmlReport").get().asFile} actual ${'$'}{task.reportDir.get().asFile}")
+                        }
+                    }
+                }
+            """.trimIndent()
+            )
+        }.generate()
+
+        val result = build.runWithParams("checkDir")
+        assertTrue(result.isSuccessful)
+    }
+}

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/tasks/KoverTasks.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/tasks/KoverTasks.kt
@@ -5,6 +5,9 @@
 package kotlinx.kover.gradle.plugin.dsl.tasks
 
 import org.gradle.api.Task
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.OutputDirectory
 
 /**
  *  Common interface for all Kover report tasks.
@@ -19,7 +22,13 @@ interface KoverXmlReport: KoverReport
 /**
  * Interface for Kover HTML report generation tasks.
  */
-interface KoverHtmlReport: KoverReport
+interface KoverHtmlReport: KoverReport {
+    /**
+     * The directory where the HTML report will be saved.
+     */
+    @get:OutputDirectory
+    val reportDir: Provider<Directory>
+}
 
 /**
  * Interface for Kover tasks that print coverage to the build log.

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/KoverHtmlTask.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/KoverHtmlTask.kt
@@ -14,7 +14,7 @@ import java.net.URI
 @CacheableTask
 internal abstract class KoverHtmlTask : AbstractKoverReportTask(), KoverHtmlReport {
     @get:OutputDirectory
-    abstract val reportDir: DirectoryProperty
+    abstract override val reportDir: DirectoryProperty
 
     @get:Input
     abstract val title: Property<String>


### PR DESCRIPTION
if there is a need to analyze the HTML report after it is generated, or if you need to improve the report (for example, by editing CSS styles), you need to know the directory of each report. Currently, it is not possible to easily link a specific report generation task and a directory.

Resolves #590