### PR TITLE
Added property variantName to KoverReport interface

### DIFF
--- a/kover-gradle-plugin/api/kover-gradle-plugin.api
+++ b/kover-gradle-plugin/api/kover-gradle-plugin.api
@@ -311,6 +311,7 @@ public abstract interface class kotlinx/kover/gradle/plugin/dsl/tasks/KoverLogRe
 }
 
 public abstract interface class kotlinx/kover/gradle/plugin/dsl/tasks/KoverReport : org/gradle/api/Task {
+	public abstract fun getVariantName ()Ljava/lang/String;
 }
 
 public abstract interface class kotlinx/kover/gradle/plugin/dsl/tasks/KoverVerifyReport : kotlinx/kover/gradle/plugin/dsl/tasks/KoverReport {

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/TaskInterfacesTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/TaskInterfacesTests.kt
@@ -3,9 +3,12 @@
  */
 package kotlinx.kover.gradle.plugin.test.functional.cases
 
+import kotlinx.kover.gradle.plugin.test.functional.framework.checker.CheckerContext
 import kotlinx.kover.gradle.plugin.test.functional.framework.runner.generateBuild
 import kotlinx.kover.gradle.plugin.test.functional.framework.runner.runWithParams
+import kotlinx.kover.gradle.plugin.test.functional.framework.starter.TemplateTest
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 internal class TaskInterfacesTests {
@@ -78,5 +81,36 @@ internal class TaskInterfacesTests {
 
         val result = build.runWithParams("checkDir")
         assertTrue(result.isSuccessful)
+    }
+
+    @TemplateTest("android-test-tasks-filtering", [":app:findAllTasks"])
+    fun CheckerContext.testTasksSearch() {
+        taskOutput(":app:findTotalTasks") {
+            assertEquals(
+                """
+                    XML=koverXmlReport
+                    HTML=koverHtmlReport
+                    Verify=koverVerify
+                    Log=koverLog
+                    Binary=koverBinaryReport
+                    
+                    """.trimIndent()
+                , this
+            )
+        }
+
+        taskOutput(":app:findDebugTasks") {
+            assertEquals(
+                """
+                    XML=koverXmlReportDebug
+                    HTML=koverHtmlReportDebug
+                    Verify=koverVerifyDebug
+                    Log=koverLogDebug
+                    Binary=koverBinaryReportDebug
+                    
+                    """.trimIndent(),
+                this
+            )
+        }
     }
 }

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/build.gradle.kts
@@ -1,0 +1,111 @@
+import kotlinx.kover.gradle.plugin.dsl.tasks.*
+
+plugins {
+    id ("org.jetbrains.kotlinx.kover")
+    id ("com.android.application")
+    id ("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "kotlinx.kover.test.android"
+    compileSdk = 32
+
+    defaultConfig {
+        applicationId = "kotlinx.kover.test.android"
+        minSdk = 21
+        targetSdk = 31
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+    buildFeatures {
+        viewBinding = true
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.8.0")
+    implementation("androidx.appcompat:appcompat:1.5.0")
+    implementation("com.google.android.material:material:1.6.1")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    testImplementation("junit:junit:4.13.2")
+}
+
+tasks.register("findAllTasks") {
+    dependsOn("findTotalTasks")
+    dependsOn("findDebugTasks")
+}
+
+tasks.register("findDebugTasks") {
+    doLast {
+        val xmlName = tasks.withType<KoverXmlReport>().matching {
+            it.variantName == "debug"
+        }.single().name
+
+        val htmlName = tasks.withType<KoverHtmlReport>().matching {
+            it.variantName == "debug"
+        }.single().name
+
+        val verifyName = tasks.withType<KoverVerifyReport>().matching {
+            it.variantName == "debug"
+        }.single().name
+
+        val logName = tasks.withType<KoverLogReport>().matching {
+            it.variantName == "debug"
+        }.single().name
+
+        val binaryName = tasks.withType<KoverBinaryReport>().matching {
+            it.variantName == "debug"
+        }.single().name
+
+        println("XML=$xmlName")
+        println("HTML=$htmlName")
+        println("Verify=$verifyName")
+        println("Log=$logName")
+        println("Binary=$binaryName")
+    }
+}
+
+tasks.register("findTotalTasks") {
+    doLast {
+        val xmlName = tasks.withType<KoverXmlReport>().matching {
+            it.variantName == ""
+        }.single().name
+
+        val htmlName = tasks.withType<KoverHtmlReport>().matching {
+            it.variantName == ""
+        }.single().name
+
+        val verifyName = tasks.withType<KoverVerifyReport>().matching {
+            it.variantName == ""
+        }.single().name
+
+        val logName = tasks.withType<KoverLogReport>().matching {
+            it.variantName == ""
+        }.single().name
+
+        val binaryName = tasks.withType<KoverBinaryReport>().matching {
+            it.variantName == ""
+        }.single().name
+
+        println("XML=$xmlName")
+        println("HTML=$htmlName")
+        println("Verify=$verifyName")
+        println("Log=$logName")
+        println("Binary=$binaryName")
+    }
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/main/AndroidManifest.xml
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application android:label="@string/app_name">
+        <uses-library android:name="com.google.android.things" android:required="false" />
+
+        <activity android:name=".MainActivity"
+                  android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <!-- Make this the first activity that is displayed when the device boots. -->
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.HOME" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/main/java/kotlinx/kover/test/android/DebugUtil.kt
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/main/java/kotlinx/kover/test/android/DebugUtil.kt
@@ -1,0 +1,7 @@
+package kotlinx.kover.test.android
+
+object DebugUtil {
+    fun log(message: String) {
+        println("DEBUG: $message")
+    }
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/main/java/kotlinx/kover/test/android/MainActivity.kt
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/main/java/kotlinx/kover/test/android/MainActivity.kt
@@ -1,0 +1,13 @@
+package kotlinx.kover.test.android
+
+import android.os.Bundle
+import android.app.Activity
+
+class MainActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+    }
+
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/main/java/kotlinx/kover/test/android/Maths.kt
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/main/java/kotlinx/kover/test/android/Maths.kt
@@ -1,0 +1,13 @@
+package kotlinx.kover.test.android
+
+object Maths {
+    fun sum(a: Int, b: Int): Int {
+        DebugUtil.log("invoked sum")
+        return a + b
+    }
+
+    fun sub(a: Int, b: Int): Int {
+        DebugUtil.log("invoked sub")
+        return a - b
+    }
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/main/res/layout/activity_main.xml
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:id="@+id/main_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="104dp"
+        android:layout_marginTop="28dp"
+        android:text="SERIALIZATION TEST"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <EditText
+        android:id="@+id/encoded_text"
+        android:layout_width="373dp"
+        android:layout_height="411dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:editable="false"
+        android:ems="10"
+        android:gravity="start|top"
+        android:inputType="textMultiLine"
+        android:textAlignment="viewStart"
+        android:textSize="12sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/main_label" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/main/res/values/colors.xml
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/main/res/values/colors.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="purple_200">#FFBB86FC</color>
+    <color name="purple_500">#FF6200EE</color>
+    <color name="purple_700">#FF3700B3</color>
+    <color name="teal_200">#FF03DAC5</color>
+    <color name="teal_700">#FF018786</color>
+    <color name="black">#FF000000</color>
+    <color name="white">#FFFFFFFF</color>
+</resources>

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/main/res/values/strings.xml
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Android Test</string>
+</resources>

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/main/res/values/themes.xml
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/main/res/values/themes.xml
@@ -1,0 +1,4 @@
+<resources>
+
+    <style name="Theme.App" parent="android:Theme.Material.Light.DarkActionBar" />
+</resources>

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/test/java/kotlinx/kover/test/android/LocalTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/app/src/test/java/kotlinx/kover/test/android/LocalTests.kt
@@ -1,0 +1,13 @@
+package kotlinx.kover.test.android
+
+import org.junit.Test
+
+import org.junit.Assert.*
+
+
+class LocalTests {
+    @Test
+    fun testDebugUtils() {
+        assertEquals(3, Maths.sum(1, 2))
+    }
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    id("com.android.application") version "7.4.0" apply false
+    id("com.android.library") version "7.4.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.8.20" apply false
+    id("org.jetbrains.kotlinx.kover") version "0.7.1" apply false
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/gradle.properties
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/gradle.properties
@@ -1,0 +1,23 @@
+# Project-wide Gradle settings.
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+# Kotlin code style for this project: "official" or "obsolete":
+kotlin.code.style=official
+# Enables namespacing of each library's R class so that its R class includes only the
+# resources declared in the library itself and none from the library's dependencies,
+# thereby reducing the size of the R class for that library
+android.nonTransitiveRClass=true

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/settings.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-test-tasks-filtering/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "android_tasks_filtering"
+include(":app")

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/tasks/VariantReportsSet.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/tasks/VariantReportsSet.kt
@@ -56,7 +56,7 @@ internal class VariantReportsSet(
             verifyCachedTaskName(variantName),
             "Task to validate coverage bounding rules for ${variantSuffix()}"
         )
-        val verifyTask = project.tasks.register<KoverVerifyTask>(verifyTaskName(variantName))
+        val verifyTask = project.tasks.register<KoverVerifyTask>(verifyTaskName(variantName), variantName)
 
         logTask = project.tasks.createReportTask<KoverFormatCoverageTask>(
             logTaskName(variantName),
@@ -176,7 +176,7 @@ internal class VariantReportsSet(
         name: String,
         taskDescription: String
     ): TaskProvider<T> {
-        val task = register<T>(name)
+        val task = register<T>(name, variantName)
         // extract property to variable so as not to create a closure to `this`
         val koverDisabledProvider = koverDisabled
         task.configure {

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/tasks/KoverTasks.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/tasks/KoverTasks.kt
@@ -7,12 +7,21 @@ package kotlinx.kover.gradle.plugin.dsl.tasks
 import org.gradle.api.Task
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 
 /**
  *  Common interface for all Kover report tasks.
  */
-interface KoverReport: Task
+interface KoverReport: Task {
+    /**
+     * The name of the report variant for Kover Gradle task.
+     *
+     * Empty string for Kover total tasks.
+     */
+    @get:Internal
+    val variantName: String
+}
 
 /**
  * Interface for Kover XML report generation tasks.

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/AbstractKoverReportTask.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/AbstractKoverReportTask.kt
@@ -12,12 +12,14 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.*
 import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.*
-import org.gradle.workers.WorkerExecutor
 import java.io.File
 import javax.inject.Inject
 
 
 internal abstract class AbstractKoverReportTask : DefaultTask() {
+    @get:Internal
+    abstract val variantName: String
+
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val localArtifact: RegularFileProperty

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/KoverBinaryTask.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/KoverBinaryTask.kt
@@ -7,9 +7,10 @@ package kotlinx.kover.gradle.plugin.tasks.reports
 import kotlinx.kover.gradle.plugin.dsl.tasks.KoverBinaryReport
 import org.gradle.api.file.*
 import org.gradle.api.tasks.*
+import javax.inject.Inject
 
 @CacheableTask
-internal abstract class KoverBinaryTask : AbstractKoverReportTask(), KoverBinaryReport {
+internal abstract class KoverBinaryTask @Inject constructor(@get:Internal override val variantName: String) : AbstractKoverReportTask(), KoverBinaryReport {
     @get:OutputFile
     internal abstract val file: RegularFileProperty
 

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/KoverDoVerifyTask.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/KoverDoVerifyTask.kt
@@ -9,9 +9,10 @@ import kotlinx.kover.gradle.plugin.tools.generateErrorMessage
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.*
+import javax.inject.Inject
 
 @CacheableTask
-internal abstract class KoverDoVerifyTask : AbstractKoverReportTask() {
+internal abstract class KoverDoVerifyTask @Inject constructor(@get:Internal override val variantName: String) : AbstractKoverReportTask() {
     @get:Nested
     abstract val rules: ListProperty<VerificationRule>
 

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/KoverFormatCoverageTask.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/KoverFormatCoverageTask.kt
@@ -13,9 +13,10 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import javax.annotation.Nullable
+import javax.inject.Inject
 
 @CacheableTask
-internal abstract class KoverFormatCoverageTask : AbstractKoverReportTask(), KoverLogReport {
+internal abstract class KoverFormatCoverageTask @Inject constructor(@get:Internal override val variantName: String) : AbstractKoverReportTask(), KoverLogReport {
     @get:Input
     @get:Optional
     @get:Nullable

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/KoverHtmlTask.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/KoverHtmlTask.kt
@@ -10,9 +10,10 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import java.io.File
 import java.net.URI
+import javax.inject.Inject
 
 @CacheableTask
-internal abstract class KoverHtmlTask : AbstractKoverReportTask(), KoverHtmlReport {
+internal abstract class KoverHtmlTask @Inject constructor(@get:Internal override val variantName: String) : AbstractKoverReportTask(), KoverHtmlReport {
     @get:OutputDirectory
     abstract override val reportDir: DirectoryProperty
 

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/KoverVerifyTask.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/KoverVerifyTask.kt
@@ -11,9 +11,10 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.work.DisableCachingByDefault
+import javax.inject.Inject
 
 @DisableCachingByDefault
-internal abstract class KoverVerifyTask : DefaultTask(), KoverVerifyReport {
+internal abstract class KoverVerifyTask @Inject constructor(@get:Internal override val variantName: String) : DefaultTask(), KoverVerifyReport {
     @get:Input
     abstract val warningInsteadOfFailure: Property<Boolean>
 

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/KoverXmlTask.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/KoverXmlTask.kt
@@ -8,9 +8,10 @@ import kotlinx.kover.gradle.plugin.dsl.tasks.KoverXmlReport
 import org.gradle.api.file.*
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
+import javax.inject.Inject
 
 @CacheableTask
-internal abstract class KoverXmlTask : AbstractKoverReportTask(), KoverXmlReport {
+internal abstract class KoverXmlTask @Inject constructor(@get:Internal override val variantName: String) : AbstractKoverReportTask(), KoverXmlReport {
     @get:OutputFile
     internal abstract val reportFile: RegularFileProperty
 


### PR DESCRIPTION
Property `variantName` will help to filter Kover tasks by selecting those that relate to specific variant.

Resolves #587