### PR TITLE
Promote status of the Kover to Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Kover
 
-[![Kotlin Alpha](https://kotl.in/badges/alpha.svg)](https://kotlinlang.org/docs/components-stability.html)
-[![JetBrains incubator project](https://jb.gg/badges/incubator.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
+[![Kotlin Beta](https://kotl.in/badges/beta.svg)](https://kotlinlang.org/docs/components-stability.html)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 
 Kover is a set of solutions for collecting test coverage of Kotlin code compiled for JVM and Android platforms.


### PR DESCRIPTION
* It is here to stay
* We would live to maintain it in its current form and have a clear vision for future development (#608) with a straightforward migration plan