### PR TITLE
Partially apply recommendations for improving DSL

### DIFF
--- a/kover-gradle-plugin/api/kover-gradle-plugin.api
+++ b/kover-gradle-plugin/api/kover-gradle-plugin.api
@@ -232,6 +232,7 @@ public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverTestsExclus
 }
 
 public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverVariantConfig {
+	public abstract fun getSources ()Lkotlinx/kover/gradle/plugin/dsl/KoverVariantSources;
 	public abstract fun sources (Lorg/gradle/api/Action;)V
 }
 

--- a/kover-gradle-plugin/api/kover-gradle-plugin.api
+++ b/kover-gradle-plugin/api/kover-gradle-plugin.api
@@ -44,6 +44,7 @@ public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverBinaryTaskC
 public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverCurrentProjectVariantsConfig : kotlinx/kover/gradle/plugin/dsl/KoverVariantConfig {
 	public abstract fun copyVariant (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun createVariant (Ljava/lang/String;Lorg/gradle/api/Action;)V
+	public abstract fun getInstrumentation ()Lkotlinx/kover/gradle/plugin/dsl/KoverProjectInstrumentation;
 	public abstract fun instrumentation (Lorg/gradle/api/Action;)V
 	public abstract fun providedVariant (Ljava/lang/String;Lorg/gradle/api/Action;)V
 	public abstract fun totalVariant (Lorg/gradle/api/Action;)V
@@ -151,7 +152,10 @@ public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverProjectExte
 	public fun excludeJavaCode ()V
 	public fun excludeSourceSets (Lorg/gradle/api/Action;)V
 	public fun excludeTests (Lorg/gradle/api/Action;)V
+	public abstract fun getCurrentProject ()Lkotlinx/kover/gradle/plugin/dsl/KoverCurrentProjectVariantsConfig;
 	public abstract fun getJacocoVersion ()Lorg/gradle/api/provider/Property;
+	public abstract fun getMerge ()Lkotlinx/kover/gradle/plugin/dsl/KoverMergingConfig;
+	public abstract fun getReports ()Lkotlinx/kover/gradle/plugin/dsl/KoverReportsConfig;
 	public abstract fun getUseJacoco ()Lorg/gradle/api/provider/Property;
 	public abstract fun merge (Lorg/gradle/api/Action;)V
 	public abstract fun reports (Lorg/gradle/api/Action;)V
@@ -173,6 +177,9 @@ public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverReportFilte
 	public abstract fun classes (Lorg/gradle/api/provider/Provider;)V
 	public abstract fun classes ([Ljava/lang/String;)V
 	public abstract fun classes ([Lorg/gradle/api/provider/Provider;)V
+	public abstract fun getAnnotatedBy ()Lorg/gradle/api/provider/SetProperty;
+	public abstract fun getClasses ()Lorg/gradle/api/provider/SetProperty;
+	public abstract fun getInheritedFrom ()Lorg/gradle/api/provider/SetProperty;
 	public abstract fun getProjects ()Lorg/gradle/api/provider/SetProperty;
 	public abstract fun inheritedFrom ([Ljava/lang/String;)V
 	public abstract fun inheritedFrom ([Lorg/gradle/api/provider/Provider;)V
@@ -184,6 +191,8 @@ public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverReportFilte
 
 public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverReportFiltersConfig {
 	public abstract fun excludes (Lorg/gradle/api/Action;)V
+	public abstract fun getExcludes ()Lkotlinx/kover/gradle/plugin/dsl/KoverReportFilter;
+	public abstract fun getIncludes ()Lkotlinx/kover/gradle/plugin/dsl/KoverReportFilter;
 	public abstract fun includes (Lorg/gradle/api/Action;)V
 }
 
@@ -191,6 +200,12 @@ public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverReportSetCo
 	public abstract fun binary (Lorg/gradle/api/Action;)V
 	public abstract fun filters (Lorg/gradle/api/Action;)V
 	public abstract fun filtersAppend (Lorg/gradle/api/Action;)V
+	public abstract fun getBinary ()Lkotlinx/kover/gradle/plugin/dsl/KoverBinaryTaskConfig;
+	public abstract fun getFilters ()Lkotlinx/kover/gradle/plugin/dsl/KoverReportFiltersConfig;
+	public abstract fun getHtml ()Lkotlinx/kover/gradle/plugin/dsl/KoverHtmlTaskConfig;
+	public abstract fun getLog ()Lkotlinx/kover/gradle/plugin/dsl/KoverLogTaskConfig;
+	public abstract fun getVerify ()Lkotlinx/kover/gradle/plugin/dsl/KoverVerifyTaskConfig;
+	public abstract fun getXml ()Lkotlinx/kover/gradle/plugin/dsl/KoverXmlTaskConfig;
 	public abstract fun html (Lorg/gradle/api/Action;)V
 	public abstract fun log (Lorg/gradle/api/Action;)V
 	public fun mergeWith (Ljava/lang/String;)V
@@ -203,6 +218,9 @@ public abstract interface class kotlinx/kover/gradle/plugin/dsl/KoverReportsConf
 	public fun androidReports (Ljava/lang/String;Lorg/gradle/api/Action;)V
 	public fun defaults (Lorg/gradle/api/Action;)V
 	public abstract fun filters (Lorg/gradle/api/Action;)V
+	public abstract fun getFilters ()Lkotlinx/kover/gradle/plugin/dsl/KoverReportFiltersConfig;
+	public abstract fun getTotal ()Lkotlinx/kover/gradle/plugin/dsl/KoverReportSetConfig;
+	public abstract fun getVerify ()Lkotlinx/kover/gradle/plugin/dsl/KoverVerificationRulesConfig;
 	public abstract fun total (Lorg/gradle/api/Action;)V
 	public abstract fun variant (Ljava/lang/String;Lorg/gradle/api/Action;)V
 	public abstract fun verify (Lorg/gradle/api/Action;)V

--- a/kover-gradle-plugin/examples/android/multiproject/app/build.gradle.kts
+++ b/kover-gradle-plugin/examples/android/multiproject/app/build.gradle.kts
@@ -56,29 +56,21 @@ dependencies {
 kover {
     reports {
         // filters for all report types of all build variants
-        filters {
-            excludes {
-                androidGeneratedClasses()
-            }
-        }
+        filters.excludes.androidGeneratedClasses()
 
         variant("release") {
             // verification only for 'release' build variant
-            verify {
-                rule {
-                    minBound(50)
-                }
+            verify.rule {
+                minBound(50)
             }
 
             // filters for all report types only for 'release' build variant
-            filters {
-                excludes {
-                    androidGeneratedClasses()
-                    classes(
-                        // excludes debug classes
-                        "*.DebugUtil"
-                    )
-                }
+            filters.excludes {
+                androidGeneratedClasses()
+                classes(
+                    // excludes debug classes
+                    "*.DebugUtil"
+                )
             }
         }
 

--- a/kover-gradle-plugin/examples/android/variantUsage/app/build.gradle.kts
+++ b/kover-gradle-plugin/examples/android/variantUsage/app/build.gradle.kts
@@ -68,9 +68,7 @@ kover {
     reports {
         // filters for all report types of all build variants
         filters {
-            excludes {
-                androidGeneratedClasses()
-            }
+            excludes.androidGeneratedClasses()
         }
 
         variant("release") {

--- a/kover-gradle-plugin/examples/jvm/merged/build.gradle.kts
+++ b/kover-gradle-plugin/examples/jvm/merged/build.gradle.kts
@@ -11,23 +11,17 @@ dependencies {
     kover(project(":subproject"))
 }
 
-kover {
-    reports {
-        filters {
-            excludes {
-                classes("kotlinx.kover.examples.merged.utils.*", "kotlinx.kover.examples.merged.subproject.utils.*")
-            }
-            includes {
-                classes("kotlinx.kover.examples.merged.*")
-            }
-        }
+kover.reports {
+    filters {
+        excludes.classes("kotlinx.kover.examples.merged.utils.*", "kotlinx.kover.examples.merged.subproject.utils.*")
+        includes.classes("kotlinx.kover.examples.merged.*")
+    }
 
-        verify {
-            rule {
-                bound {
-                    minValue.set(50)
-                    maxValue.set(75)
-                }
+    verify {
+        rule {
+            bound {
+                minValue.set(50)
+                maxValue.set(75)
             }
         }
     }

--- a/kover-gradle-plugin/examples/jvm/single-kmp/build.gradle.kts
+++ b/kover-gradle-plugin/examples/jvm/single-kmp/build.gradle.kts
@@ -13,12 +13,6 @@ dependencies {
     commonTestImplementation(kotlin("test"))
 }
 
-kover {
-    reports {
-        verify {
-            rule {
-                minBound(50)
-            }
-        }
-    }
+kover.reports.verify.rule {
+    minBound(50)
 }

--- a/kover-gradle-plugin/examples/jvm/single/build.gradle.kts
+++ b/kover-gradle-plugin/examples/jvm/single/build.gradle.kts
@@ -7,12 +7,6 @@ dependencies {
     testImplementation(kotlin("test"))
 }
 
-kover {
-    reports {
-        verify {
-            rule {
-                minBound(50)
-            }
-        }
-    }
+kover.reports.verify.rule {
+    minBound(50)
 }

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/MergingTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/MergingTests.kt
@@ -62,6 +62,35 @@ internal class MergingTests {
     }
 
     @GeneratedTest
+    fun BuildConfigurator.testRootSubprojectsWithProperty() {
+        addProjectWithKover {
+            sourcesFrom("simple")
+            kover {
+                // merge with all subprojects
+                merge.subprojects()
+            }
+        }
+        addProjectWithKover(":one") {
+            sourcesFrom("one")
+        }
+        addProjectWithKover(":two") {
+            sourcesFrom("two")
+        }
+
+        run(":koverXmlReport") {
+            checkOutcome(":koverGenerateArtifact", "SUCCESS")
+            checkOutcome(":one:koverGenerateArtifact", "SUCCESS")
+            checkOutcome(":two:koverGenerateArtifact", "SUCCESS")
+
+            xmlReport {
+                classCounter("org.jetbrains.ExampleClass").assertCovered()
+                classCounter("org.jetbrains.one.OneClass").assertCovered()
+                classCounter("org.jetbrains.two.TwoClass").assertCovered()
+            }
+        }
+    }
+
+    @GeneratedTest
     fun BuildConfigurator.testRootSubprojectsByPath() {
         addProjectWithKover {
             sourcesFrom("simple")

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ReportAnnotationFilterTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ReportAnnotationFilterTests.kt
@@ -51,9 +51,7 @@ internal class ReportAnnotationFilterTests {
                             classes("*ByName")
                             annotatedBy("org.jetbrains.Exclude")
                         }
-                        includes {
-                            annotatedBy("*.Include")
-                        }
+                        includes.annotatedBy("*.Include")
                     }
                 }
             }

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/sourcesets-mpp/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/sourcesets-mpp/build.gradle.kts
@@ -3,13 +3,7 @@ plugins {
     id("org.jetbrains.kotlinx.kover") version "0.7.0"
 }
 
-kover {
-    currentProject {
-        sources {
-            excludedSourceSets.add("extra")
-        }
-    }
-}
+kover.currentProject.sources.excludedSourceSets.add("extra")
 
 sourceSets.create("extra")
 

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/KoverMerge.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/KoverMerge.kt
@@ -15,7 +15,7 @@ import org.gradle.api.provider.SetProperty
 import org.gradle.api.specs.Spec
 
 internal fun KoverContext.prepareMerging() {
-    if (!projectExtension.isMerged) return
+    if (!projectExtension.merge.configured) return
 
     val projects = selectProjects()
     configSelectedProjects(projects)
@@ -23,7 +23,7 @@ internal fun KoverContext.prepareMerging() {
 
 
 private fun KoverContext.selectProjects(): List<Project> {
-    val result = linkedMapOf<String, Project>(project.path to project)
+    val result = linkedMapOf(project.path to project)
 
     fun addProjectIfFiltered(project: Project, filters: List<Spec<Project>>) {
         if (result.containsKey(project.path)) return
@@ -83,10 +83,10 @@ private fun KoverProjectExtensionImpl.configBeforeFinalize(targetProject: Projec
             targetExtension.jacocoVersion.set(jacocoVersion)
         }
 
-        merge.sourcesAction?.execute(targetExtension.current.sources.wrap(targetProject))
-        merge.instrumentationAction?.execute(targetExtension.current.instrumentation.wrap(targetProject))
+        merge.sourcesAction?.execute(targetExtension.currentProject.sources.wrap(targetProject))
+        merge.instrumentationAction?.execute(targetExtension.currentProject.instrumentation.wrap(targetProject))
         merge.variantsAction.forEach { (variantName, action) ->
-            targetExtension.current.createVariant(variantName) {
+            targetExtension.currentProject.createVariant(variantName) {
                 action.execute(wrap(targetProject))
             }
         }

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/KoverMerge.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/KoverMerge.kt
@@ -111,6 +111,7 @@ private fun KoverProjectInstrumentation.wrap(project: Project): KoverMergingInst
 }
 private fun KoverVariantCreateConfig.wrap(project: Project): KoverMergingVariantCreate {
     return object : KoverMergingVariantCreate {
+        override val sources: KoverVariantSources = this@wrap.sources
         override fun sources(block: Action<KoverVariantSources>) = this@wrap.sources(block)
         override fun add(vararg variantNames: String, optional: Boolean) = this@wrap.add(*variantNames, optional = optional)
         override fun addWithDependencies(vararg variantNames: String, optional: Boolean) = this@wrap.addWithDependencies(*variantNames, optional = optional)

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/artifacts/AbstractVariantArtifacts.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/artifacts/AbstractVariantArtifacts.kt
@@ -68,8 +68,8 @@ internal sealed class AbstractVariantArtifacts(
     }
 
     protected fun fromOrigin(origin: VariantOrigin, compilationFilter: (String) -> Boolean = { true }) {
-        val excludedTasks = projectExtension.current.instrumentation.disabledForTestTasks
-        val disabledInstrumentation = projectExtension.current.instrumentation.disabledForAll
+        val excludedTasks = projectExtension.currentProject.instrumentation.disabledForTestTasks
+        val disabledInstrumentation = projectExtension.currentProject.instrumentation.disabledForAll
 
         val tests = origin.tests.matching {
             !disabledInstrumentation.get()

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/tasks/VariantReportsSet.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/tasks/VariantReportsSet.kt
@@ -212,14 +212,14 @@ internal class VariantReportsSet(
     private fun KoverReportFiltersConfigImpl.convert(): Provider<ReportFilters> {
         return project.provider {
             ReportFilters(
-                includesImpl.classes.get(),
-                includesImpl.annotations.get(),
-                includesImpl.inheritedFrom.get(),
-                includesImpl.projects.get(),
-                excludesImpl.classes.get(),
-                excludesImpl.annotations.get(),
-                excludesImpl.inheritedFrom.get(),
-                excludesImpl.projects.get()
+                includes.classes.get(),
+                includes.annotatedBy.get(),
+                includes.inheritedFrom.get(),
+                includes.projects.get(),
+                excludes.classes.get(),
+                excludes.annotatedBy.get(),
+                excludes.inheritedFrom.get(),
+                excludes.projects.get()
             )
         }
     }

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverProjectExtension.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverProjectExtension.kt
@@ -81,6 +81,13 @@ public interface KoverProjectExtension {
     public fun currentProject(block: Action<KoverCurrentProjectVariantsConfig>)
 
     /**
+     * Instance to configuring of report variants shared by the current project.
+     *
+     * See details in [currentProject].
+     */
+    public val currentProject: KoverCurrentProjectVariantsConfig
+
+    /**
      * Configuration of Kover reports.
      *
      * An individual set of reports is created for each Kover report variant.
@@ -119,6 +126,13 @@ public interface KoverProjectExtension {
      * ```
      */
     public fun reports(block: Action<KoverReportsConfig>)
+
+    /**
+     * Instance to configuring of Kover reports.
+     *
+     * See details in [reports].
+     */
+    public val reports: KoverReportsConfig
 
     /**
      * Configuring a merged report.
@@ -200,6 +214,13 @@ public interface KoverProjectExtension {
      * ```
      */
     public fun merge(block: Action<KoverMergingConfig>)
+
+    /**
+     * Instance to configuring a merged report.
+     *
+     * See details in [merge].
+     */
+    public val merge: KoverMergingConfig
 
     @Deprecated(
         message = "Function excludeJavaCode was removed, to exclude all Java sources write here `currentProject { sources { excludeJava = true } }` or `currentProject { sources { excludeJava.set(true) } } instead. Please refer to migration guide in order to migrate: ${KoverMigrations.MIGRATION_0_7_TO_0_8}",

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverReportsConfig.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverReportsConfig.kt
@@ -91,6 +91,12 @@ public interface KoverReportsConfig {
      */
     public fun filters(config: Action<KoverReportFiltersConfig>)
 
+    /**
+     * Instance to configuring of common filters for all report variants.
+     *
+     * See details in [filters].
+     */
+    public val filters: KoverReportFiltersConfig
 
     /**
      * Specify common verification rules for all report variants: JVM and Android build variants.
@@ -111,6 +117,13 @@ public interface KoverReportsConfig {
      * ```
      */
     public fun verify(config: Action<KoverVerificationRulesConfig>)
+
+    /**
+     * Instance to configuring of common verification rules for all report variants.
+     *
+     * See details in [verify].
+     */
+    public val verify: KoverVerificationRulesConfig
 
     @Deprecated(
         message = "Default reports was removed, the concepts of total and custom reports are now used. Please refer to migration guide in order to migrate: ${KoverMigrations.MIGRATION_0_7_TO_0_8}",
@@ -155,6 +168,13 @@ public interface KoverReportsConfig {
      * ```
      */
     public fun total(config: Action<KoverReportSetConfig>)
+
+    /**
+     * Instance to configuring of reports for all code of current project and `kover` dependencies.
+     *
+     * See details in [total].
+     */
+    public val total: KoverReportSetConfig
 
     /**
      * Configure reports for classes of specified named Kover report variant.
@@ -230,6 +250,13 @@ public interface KoverReportSetConfig {
     public fun filters(config: Action<KoverReportFiltersConfig>)
 
     /**
+     * Instance to configuring of common report filters.
+     *
+     * See details in [filters].
+     */
+    public val filters: KoverReportFiltersConfig
+
+    /**
      * Specify common report filters, these filters will be inherited in HTML/XML/verification and other reports.
      *
      * Using this block will add additional filters to those that were inherited and specified earlier.
@@ -268,6 +295,13 @@ public interface KoverReportSetConfig {
     public fun html(config: Action<KoverHtmlTaskConfig>)
 
     /**
+     * Instance to configuring of HTML report for current report variant.
+     *
+     * See details in [html].
+     */
+    public val html: KoverHtmlTaskConfig
+
+    /**
      * Configure XML report for current report variant.
      * ```
      * xml {
@@ -285,6 +319,13 @@ public interface KoverReportSetConfig {
     public fun xml(config: Action<KoverXmlTaskConfig>)
 
     /**
+     * Instance to configuring of XML report for current report variant.
+     *
+     * See details in [xml].
+     */
+    public val xml: KoverXmlTaskConfig
+
+    /**
      * Configure Kover binary report for current report variant.
      * ```
      * binary {
@@ -299,6 +340,13 @@ public interface KoverReportSetConfig {
      * Kover binary report is compatible with IntelliJ Coverage report (ic)
      */
     public fun binary(config: Action<KoverBinaryTaskConfig>)
+
+    /**
+     * Instance to configuring of Kover binary report for current report variant.
+     *
+     * See details in [binary].
+     */
+    public val binary: KoverBinaryTaskConfig
 
     /**
      * Configure coverage verification for current report variant.
@@ -324,6 +372,13 @@ public interface KoverReportSetConfig {
      * ```
      */
     public fun verify(config: Action<KoverVerifyTaskConfig>)
+
+    /**
+     * Instance to configuring of coverage verification for current report variant.
+     *
+     * See details in [verify].
+     */
+    public val verify: KoverVerifyTaskConfig
 
     /**
      * Configure coverage verification for current report variant.
@@ -365,6 +420,13 @@ public interface KoverReportSetConfig {
      * ```
      */
     public fun log(config: Action<KoverLogTaskConfig>)
+
+    /**
+     * Instance to configuring of  coverage printing to the log for current report variant.
+     *
+     * See details in [log].
+     */
+    public val log: KoverLogTaskConfig
 
     @Deprecated(
         message = "Block mergeWith was removed, create custom reports variant and merge with specified variant. Please refer to migration guide in order to migrate: ${KoverMigrations.MIGRATION_0_7_TO_0_8}",
@@ -476,6 +538,13 @@ public interface KoverReportFiltersConfig {
     public fun excludes(config: Action<KoverReportFilter>)
 
     /**
+     * Instance to configuring of class filter in order to exclude classes and functions.
+     *
+     * See details in [excludes].
+     */
+    public val excludes: KoverReportFilter
+
+    /**
      * Configures class filter in order to include classes.
      *
      * Example:
@@ -490,6 +559,13 @@ public interface KoverReportFiltersConfig {
      * Excludes have priority over includes.
      */
     public fun includes(config: Action<KoverReportFilter>)
+
+    /**
+     * Instance to configuring of class filter in order to include classes.
+     *
+     * See details in [includes].
+     */
+    public val includes: KoverReportFilter
 }
 
 /**
@@ -578,6 +654,19 @@ public interface KoverReportFilter {
      * ```
      */
     public fun classes(names: Provider<Iterable<String>>)
+
+    /**
+     * Classes of current filter.
+     *
+     * It is acceptable to use `*` and `?` wildcards,
+     * `*` means any number of arbitrary characters (including no chars), `?` means one arbitrary character.
+     *
+     * Example:
+     * ```
+     *  classes.addAll("*.foo.Bar", "*.M?Class")
+     * ```
+     */
+    public val classes: SetProperty<String>
 
     /**
      * Add all classes in specified package and its subpackages to current filters.
@@ -690,6 +779,25 @@ public interface KoverReportFilter {
     public fun annotatedBy(vararg annotationName: Provider<String>)
 
     /**
+     * Filters for classes and functions marked by specified annotations.
+     *
+     * Use cases:
+     *  - in case of exclusion filters all classes or function marked by at least one of the specified annotation will be excluded from the report
+     *  - in case of inclusion filters only classes marked by at least one of the specified annotations will be included in the report
+     *
+     * It is acceptable to use `*` and `?` wildcards,
+     * `*` means any number of arbitrary characters (including no chars), `?` means one arbitrary character.
+     *
+     * **_Does not work for JaCoCo_**
+     *
+     * Example:
+     * ```
+     *  annotatedBy.addAll("*Generated*", "com.example.KoverExclude")
+     * ```
+     */
+    public val annotatedBy: SetProperty<String>
+
+    /**
      * Add all classes in specified project. Only the project path is used (starts with a colon).
      *
      * It is acceptable to use `*` and `?` wildcards,
@@ -755,6 +863,32 @@ public interface KoverReportFilter {
      * ```
      */
     public fun inheritedFrom(vararg typeName: Provider<String>)
+
+    /**
+     * Filter classes extending at least one of the specified classes or implementing at least one of the interfaces.
+     * The class itself with the specified name is not taken into account.
+     *
+     * The entire inheritance tree is analyzed; a class may inherit the specified class/interface indirectly and still be included in the report, unless the specified class/interface is located outside of the application (see below).
+     *
+     * The following classes and interfaces can be specified in arguments:
+     *  - classes and interfaces declared in the application
+     *  - classes and interfaces declared outside the application, however they are directly inherited or implemented by any type from the application
+     *
+     * Due to technical limitations, if a specified class or interface is not declared in the application and not extended/implemented directly by one of the application types, such a filter will have no effect.
+     *
+     * If this filter is specified, then the generation of the report may slow down, because it becomes necessary to analyze the inheritance tree.
+     *
+     * It is acceptable to use `*` and `?` wildcards,
+     * `*` means any number of arbitrary characters (including no chars), `?` means one arbitrary character.
+     *
+     * **_Does not work for JaCoCo_**
+     *
+     * Example:
+     * ```
+     *  inheritedFrom.add("*Repository")
+     * ```
+     */
+    public val inheritedFrom: SetProperty<String>
 
     /**
      * Add all classes generated by Android plugin to filters.

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverVariantConfig.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverVariantConfig.kt
@@ -95,6 +95,13 @@ public interface KoverCurrentProjectVariantsConfig: KoverVariantConfig {
      * ```
      */
     public fun instrumentation(block: Action<KoverProjectInstrumentation>)
+
+    /**
+     * Instance to configuring of instrumentation for the current Gradle project.
+     *
+     * See details in [instrumentation].
+     */
+    public val instrumentation: KoverProjectInstrumentation
 }
 
 /**

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverVariantConfig.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/KoverVariantConfig.kt
@@ -6,6 +6,7 @@ package kotlinx.kover.gradle.plugin.dsl
 
 import kotlinx.kover.gradle.plugin.commons.KoverIllegalConfigException
 import org.gradle.api.Action
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 
@@ -127,6 +128,13 @@ public interface KoverVariantConfig {
      * ```
      */
     public fun sources(block: Action<KoverVariantSources>)
+
+    /**
+     * Instance to limit the classes that will be included in the reports.
+     *
+     * See details in [sources].
+     */
+    public val sources: KoverVariantSources
 }
 
 /**

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/internal/MergeImpl.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/internal/MergeImpl.kt
@@ -17,25 +17,31 @@ internal abstract class KoverMergingConfigImpl: KoverMergingConfig {
     internal var instrumentationAction: Action<KoverMergingInstrumentation>? = null
     internal val variantsAction: MutableMap<String, Action<KoverMergingVariantCreate>> = mutableMapOf()
 
+    internal var configured: Boolean = false
 
     override fun subprojects() {
         subprojectsFilters += Spec<Project> { true }
+        configured = true
     }
 
     override fun subprojects(filter: Spec<Project>) {
         subprojectsFilters += filter
+        configured = true
     }
 
     override fun allProjects() {
         allProjectsFilters += Spec<Project> { true }
+        configured = true
     }
 
     override fun allProjects(filter: Spec<Project>) {
         allProjectsFilters += filter
+        configured = true
     }
 
     override fun projects(vararg projectNameOrPath: String) {
         allProjectsFilters += Spec<Project> { project -> project.name in projectNameOrPath || project.path in projectNameOrPath }
+        configured = true
     }
 
     override fun sources(config: Action<KoverMergingVariantSources>) {
@@ -43,6 +49,7 @@ internal abstract class KoverMergingConfigImpl: KoverMergingConfig {
             throw KoverIllegalConfigException("An attempt to re-invoke the 'sources' block in merging config. Only one usage is allowed")
         }
         sourcesAction = config
+        configured = true
     }
 
     override fun instrumentation(config: Action<KoverMergingInstrumentation>) {
@@ -50,6 +57,7 @@ internal abstract class KoverMergingConfigImpl: KoverMergingConfig {
             throw KoverIllegalConfigException("An attempt to re-invoke the 'instrumentation' block in merging config. Only one usage is allowed")
         }
         instrumentationAction = config
+        configured = true
     }
 
     override fun createVariant(variantName: String, config: Action<KoverMergingVariantCreate>) {
@@ -57,6 +65,7 @@ internal abstract class KoverMergingConfigImpl: KoverMergingConfig {
         if (prev != null) {
             throw KoverIllegalConfigException("Variant '$variantName' has already been added in merging config. Re-creating a variant with the same name is not allowed")
         }
+        configured = true
     }
 
 }

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/internal/ReportsImpl.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/internal/ReportsImpl.kt
@@ -23,19 +23,18 @@ internal abstract class KoverReportsConfigImpl @Inject constructor(
     private val layout: ProjectLayout,
     private val projectPath: String
 ) : KoverReportsConfig {
-    private val rootFilters: KoverReportFiltersConfigImpl = objects.newInstance()
-    private val rootVerify: KoverVerificationRulesConfigImpl = objects.newInstance()
-
-    internal val total: KoverReportSetConfigImpl = createReportSet(TOTAL_VARIANT_NAME, projectPath)
+    override val filters: KoverReportFiltersConfigImpl = objects.newInstance()
+    override val verify: KoverVerificationRulesConfigImpl = objects.newInstance()
+    override val total: KoverReportSetConfigImpl = createReportSet(TOTAL_VARIANT_NAME, projectPath)
 
     internal val byName: MutableMap<String, KoverReportSetConfigImpl> = mutableMapOf()
 
     override fun filters(config: Action<KoverReportFiltersConfig>) {
-        rootFilters.also { config(it) }
+        filters.also { config(it) }
     }
 
     override fun verify(config: Action<KoverVerificationRulesConfig>) {
-        rootVerify.also { config(it) }
+        verify.also { config(it) }
     }
 
     override fun total(config: Action<KoverReportSetConfig>) {
@@ -53,8 +52,8 @@ internal abstract class KoverReportsConfigImpl @Inject constructor(
         val block =
             objects.newInstance<KoverReportSetConfigImpl>(objects, layout.buildDirectory, variantName, projectPath)
 
-        block.filters.extendsFrom(rootFilters)
-        block.verify.extendFrom(rootVerify)
+        block.filters.extendsFrom(filters)
+        block.verify.extendFrom(verify)
 
         return block
     }
@@ -66,13 +65,13 @@ internal abstract class KoverReportSetConfigImpl @Inject constructor(
     variantName: String,
     projectPath: String
 ) : KoverReportSetConfig {
-    internal val filters: KoverReportFiltersConfigImpl = objects.newInstance()
-    internal val verify: KoverVerifyTaskConfigImpl = objects.newInstance()
+    override val filters: KoverReportFiltersConfigImpl = objects.newInstance()
+    override val verify: KoverVerifyTaskConfigImpl = objects.newInstance()
 
-    internal val html: KoverHtmlTaskConfig = objects.newInstance()
-    internal val xml: KoverXmlTaskConfig = objects.newInstance()
-    internal val binary: KoverBinaryTaskConfig = objects.newInstance()
-    internal val log: KoverLogTaskConfig = objects.newInstance()
+    override val html: KoverHtmlTaskConfig = objects.newInstance()
+    override val xml: KoverXmlTaskConfig = objects.newInstance()
+    override val binary: KoverBinaryTaskConfig = objects.newInstance()
+    override val log: KoverLogTaskConfig = objects.newInstance()
 
     init {
         xml.xmlFile.convention(buildDir.file(xmlReportPath(variantName)))
@@ -244,33 +243,33 @@ internal abstract class KoverVerifyRuleImpl @Inject constructor(private val obje
 internal open class KoverReportFiltersConfigImpl @Inject constructor(
     objects: ObjectFactory
 ) : KoverReportFiltersConfig {
-    internal val excludesImpl: KoverReportFilterImpl = objects.newInstance()
-    internal val includesImpl: KoverReportFilterImpl = objects.newInstance()
+    override val excludes: KoverReportFilterImpl = objects.newInstance()
+    override val includes: KoverReportFilterImpl = objects.newInstance()
 
     override fun excludes(config: Action<KoverReportFilter>) {
-        config(excludesImpl)
+        config(excludes)
     }
 
     override fun includes(config: Action<KoverReportFilter>) {
-        config(includesImpl)
+        config(includes)
     }
 
     internal fun clean() {
-        excludesImpl.clean()
-        includesImpl.clean()
+        excludes.clean()
+        includes.clean()
     }
 
     internal fun extendsFrom(other: KoverReportFiltersConfigImpl) {
-        excludesImpl.extendsFrom(other.excludesImpl)
-        includesImpl.extendsFrom(other.includesImpl)
+        excludes.extendsFrom(other.excludes)
+        includes.extendsFrom(other.includes)
     }
 }
 
 
 internal abstract class KoverReportFilterImpl: KoverReportFilter {
-    internal abstract val classes: SetProperty<String>
-    internal abstract val annotations: SetProperty<String>
-    internal abstract val inheritedFrom: SetProperty<String>
+    abstract override val classes: SetProperty<String>
+    abstract override val annotatedBy: SetProperty<String>
+    abstract override val inheritedFrom: SetProperty<String>
 
     override fun classes(vararg names: String) {
         classes.addAll(*names)
@@ -315,12 +314,12 @@ internal abstract class KoverReportFilterImpl: KoverReportFilter {
     }
 
     override fun annotatedBy(vararg annotationName: String) {
-        annotations.addAll(*annotationName)
+        annotatedBy.addAll(*annotationName)
     }
 
     override fun annotatedBy(vararg annotationName: Provider<String>) {
         annotationName.forEach { nameProvider ->
-            annotations.add(nameProvider)
+            annotatedBy.add(nameProvider)
         }
     }
     override fun inheritedFrom(vararg typeName: String) {
@@ -335,14 +334,14 @@ internal abstract class KoverReportFilterImpl: KoverReportFilter {
 
     internal fun extendsFrom(other: KoverReportFilterImpl) {
         classes.addAll(other.classes)
-        annotations.addAll(other.annotations)
+        annotatedBy.addAll(other.annotatedBy)
         projects.addAll(other.projects)
         inheritedFrom.addAll(other.inheritedFrom)
     }
 
     internal fun clean() {
         classes.empty()
-        annotations.empty()
+        annotatedBy.empty()
         inheritedFrom.empty()
         projects.empty()
     }

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/internal/VariantsImpl.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/internal/VariantsImpl.kt
@@ -81,7 +81,7 @@ internal abstract class KoverCurrentProjectVariantsConfigImpl @Inject constructo
 }
 
 internal abstract class KoverVariantConfigImpl @Inject constructor(objects: ObjectFactory) : KoverVariantConfig {
-    internal val sources: KoverVariantSources = objects.newInstance()
+    override val sources: KoverVariantSources = objects.newInstance()
 
     override fun sources(block: Action<KoverVariantSources>) {
         block.execute(sources)

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/internal/VariantsImpl.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/dsl/internal/VariantsImpl.kt
@@ -17,7 +17,8 @@ internal abstract class KoverCurrentProjectVariantsConfigImpl @Inject constructo
     internal val customVariants: MutableMap<String, KoverVariantCreateConfigImpl> = mutableMapOf()
     internal val providedVariants: MutableMap<String, KoverVariantConfigImpl> = mutableMapOf()
     internal val variantsToCopy: MutableMap<String, String> = mutableMapOf()
-    internal val instrumentation: KoverProjectInstrumentation = objects.newInstance()
+
+    final override val instrumentation: KoverProjectInstrumentation = objects.newInstance()
 
     init {
         sources.excludeJava.convention(false)


### PR DESCRIPTION
The new DSL will allow to write chains like `kover.reports.total { ... }` instead of `kover { reports { total { ... } } }`.

However, the DomainObjectContainer for variants has not been implemented, because it will be necessary to rework the workflow with different types of variants, which is part of a larger reworking of the DSL.

Resolves #600