### PR TITLE
Disable caching on kover artifact tasks

### DIFF
--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/BuildCacheRelocationTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/BuildCacheRelocationTests.kt
@@ -55,7 +55,7 @@ class BuildCacheRelocationTests {
         val result2 = gradleBuild2.runWithParams("koverXmlReport", "koverHtmlReport", "koverBinaryReport", "koverVerify", "--build-cache", "--info")
         try {
             assertEquals("FROM-CACHE", result2.taskOutcome(":test"))
-            assertEquals("FROM-CACHE", result2.taskOutcome(":koverGenerateArtifact"))
+            assertEquals("SUCCESS", result2.taskOutcome(":koverGenerateArtifact"))
             assertEquals("FROM-CACHE", result2.taskOutcome(":koverXmlReport"))
             assertEquals("FROM-CACHE", result2.taskOutcome(":koverHtmlReport"))
             assertEquals("FROM-CACHE", result2.taskOutcome(":koverBinaryReport"))

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/services/KoverArtifactGenerationTask.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/services/KoverArtifactGenerationTask.kt
@@ -11,6 +11,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.*
 import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.*
+import org.gradle.work.DisableCachingByDefault
 import java.io.*
 import javax.inject.*
 
@@ -19,6 +20,7 @@ import javax.inject.*
  *
  * This artifact that will be shared between projects through dependencies for creating merged reports.
  */
+@DisableCachingByDefault(because = "The task action is so quick that cache does not provide a benefit")
 internal abstract class KoverArtifactGenerationTask : DefaultTask() {
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/services/KoverArtifactGenerationTask.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/services/KoverArtifactGenerationTask.kt
@@ -19,7 +19,6 @@ import javax.inject.*
  *
  * This artifact that will be shared between projects through dependencies for creating merged reports.
  */
-@CacheableTask
 internal abstract class KoverArtifactGenerationTask : DefaultTask() {
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)


### PR DESCRIPTION
Fixes https://github.com/Kotlin/kotlinx-kover/issues/633

Alternative solution to https://github.com/Kotlin/kotlinx-kover/pull/636

Caching should only be enabled for tasks that do heavy computations and this task does not do so.

Potentially it would be good to merge both PRs, even if caching is disabled, we should make sure that data that is used to produce an output is declared as an import. 
