### PR TITLE
Fixed reusing of configuration cache

### DIFF
--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ConfigurationCacheTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/ConfigurationCacheTests.kt
@@ -29,6 +29,19 @@ internal class ConfigurationCacheTests {
             "koverVerify",
             "--configuration-cache",
         )
+
+        // test reusing configuration cache
+        run(
+            "build",
+            "koverXmlReport",
+            "koverHtmlReport",
+            "koverVerify",
+            "--configuration-cache",
+        ) {
+            output.match {
+                assertContains("Reusing configuration cache.")
+            }
+        }
     }
 
     @GeneratedTest

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/PrepareKover.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/PrepareKover.kt
@@ -23,6 +23,9 @@ internal fun prepare(project: Project): KoverContext {
         asBucket()
     }
 
+    // Project always consumes its own artifacts
+    project.dependencies.add(KOVER_DEPENDENCY_NAME, project)
+
     val projectExtension = project.extensions.create<KoverProjectExtensionImpl>(
         KOVER_PROJECT_EXTENSION_NAME,
         project.objects,

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/tasks/VariantReportsSet.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/tasks/VariantReportsSet.kt
@@ -192,11 +192,8 @@ internal class VariantReportsSet(
 
     private fun <T : AbstractKoverReportTask> TaskProvider<T>.assign(variant: AbstractVariantArtifacts) {
         configure {
-            dependsOn(variant.artifactGenTask)
             dependsOn(variant.consumerConfiguration)
-
-            localArtifact.set(variant.artifactGenTask.flatMap { task -> task.artifactFile })
-            externalArtifacts.from(variant.consumerConfiguration)
+            artifacts.from(variant.consumerConfiguration)
         }
     }
 

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/AbstractKoverReportTask.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/reports/AbstractKoverReportTask.kt
@@ -21,13 +21,9 @@ internal abstract class AbstractKoverReportTask : DefaultTask() {
     @get:Internal
     abstract val variantName: String
 
-    @get:InputFile
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val localArtifact: RegularFileProperty
-
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val externalArtifacts: ConfigurableFileCollection
+    abstract val artifacts: ConfigurableFileCollection
 
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -38,7 +34,7 @@ internal abstract class AbstractKoverReportTask : DefaultTask() {
      */
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    internal val externalSources: Provider<Set<File>> = externalArtifacts.elements.map {
+    internal val sources: Provider<Set<File>> = artifacts.elements.map {
         val content = ArtifactContent.Empty
         content.joinWith(it.map { file -> file.asFile.parseArtifactFile(rootDir).filterProjectSources() }).sources
     }
@@ -48,27 +44,9 @@ internal abstract class AbstractKoverReportTask : DefaultTask() {
      */
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    internal val externalReports: Provider<Set<File>> = externalArtifacts.elements.map {
+    internal val reports: Provider<Set<File>> = artifacts.elements.map {
         val content = ArtifactContent.Empty
         content.joinWith(it.map { file -> file.asFile.parseArtifactFile(rootDir).filterProjectSources() }).reports
-    }
-
-    /**
-     * This will cause the task to be considered out-of-date when source files of this project have changed.
-     */
-    @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    internal val localSources: Provider<Set<File>> = localArtifact.map {
-        it.asFile.parseArtifactFile(rootDir).filterProjectSources().sources
-    }
-
-    /**
-     * This will cause the task to be considered out-of-date when coverage measurements of this project have changed.
-     */
-    @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    internal val localReports: Provider<Set<File>> = localArtifact.map {
-        it.asFile.parseArtifactFile(rootDir).filterProjectSources().reports
     }
 
     @get:Nested
@@ -95,8 +73,8 @@ internal abstract class AbstractKoverReportTask : DefaultTask() {
     }
 
     private fun collectAllFiles(): ArtifactContent {
-        val local = localArtifact.get().asFile.parseArtifactFile(rootDir).filterProjectSources()
-        return local.joinWith(externalArtifacts.files.map { it.parseArtifactFile(rootDir).filterProjectSources() }).existing()
+        val local = ArtifactContent(projectPath, emptySet(), emptySet(), emptySet())
+        return local.joinWith(artifacts.files.map { it.parseArtifactFile(rootDir).filterProjectSources() }).existing()
     }
 
     private fun ArtifactContent.filterProjectSources(): ArtifactContent {


### PR DESCRIPTION
Due to the fact that a file was used as task input, it was placed in the configuration cache as entry, and changing this file causes the cache invalidation.

Problem in line `localArtifact.set(variant.artifactGenTask.flatMap { task -> task.artifactFile })`. flatMap function behaves strangely enough with the configuration cache, see also https://github.com/gradle/gradle/issues/25645

Fixes #646