### PR TITLE
Fixed warning for empty Kotlin plugin configuration

### DIFF
--- a/kover-maven-plugin/src/functionalTest/kotlin/kotlinx/kover/maven/plugin/tests/functional/cases/MavenPluginTests.kt
+++ b/kover-maven-plugin/src/functionalTest/kotlin/kotlinx/kover/maven/plugin/tests/functional/cases/MavenPluginTests.kt
@@ -14,6 +14,8 @@ import kotlinx.kover.maven.plugin.tests.functional.framework.CounterAssert.*
 import kotlinx.kover.maven.plugin.tests.functional.framework.CounterType.LINE
 import org.junit.jupiter.api.Test
 import java.io.File
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class MavenPluginTests {
@@ -262,6 +264,12 @@ Rule violated:
     fun testHtmlCharset() = runAndCheckExample("charset", "verify") {
         assertBuildIsSuccessful()
         assertDefaultHtmlTitle("charset", "UTF-16BE")
+    }
+
+    @Test
+    fun testEmptyKotlinConfig() = runAndCheckTest("kotlin-empty-config", "verify") {
+        assertBuildIsSuccessful()
+        assertFalse("java.lang.NullPointerException" in log, "NPE should not be thrown")
     }
 
 }

--- a/kover-maven-plugin/src/functionalTest/kotlin/kotlinx/kover/maven/plugin/tests/functional/framework/Checker.kt
+++ b/kover-maven-plugin/src/functionalTest/kotlin/kotlinx/kover/maven/plugin/tests/functional/framework/Checker.kt
@@ -8,14 +8,22 @@ import java.io.File
 import java.nio.file.Files
 
 private const val EXAMPLES_DIR = "examples"
+private const val TESTS_DIR = "src/functionalTest/templates/tests"
 
 fun runAndCheckExample(name: String, vararg args: String, checker: CheckerContext.() -> Unit) {
     val exampleDir = File(EXAMPLES_DIR).resolve(name)
     if (!exampleDir.exists()) {
         throw MavenAssertionException("Example '$exampleDir' not found in directory '$EXAMPLES_DIR'")
     }
-
     exampleDir.runAndCheck(args.toList(), checker)
+}
+
+fun runAndCheckTest(name: String, vararg args: String, checker: CheckerContext.() -> Unit) {
+    val testDir = File(TESTS_DIR).resolve(name)
+    if (!testDir.exists()) {
+        throw MavenAssertionException("Test '$testDir' not found in directory '$TESTS_DIR'")
+    }
+    testDir.runAndCheck(args.toList(), checker)
 }
 
 private fun File.runAndCheck(commands: List<String>, checker: CheckerContext.() -> Unit) {

--- a/kover-maven-plugin/src/functionalTest/templates/tests/kotlin-empty-config/pom.xml
+++ b/kover-maven-plugin/src/functionalTest/templates/tests/kotlin-empty-config/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017-2024 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>charset</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <kotlin.code.style>official</kotlin.code.style>
+        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
+        <kover.version>0.8.2</kover.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>mavenCentral</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <sourceDirectory>src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile-kotlin</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <!-- There are no configs -->
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kover-maven-plugin</artifactId>
+                <version>${kover.version}</version>
+                <executions>
+                    <execution>
+                        <id>instr</id>
+                        <goals>
+                            <goal>instrumentation</goal>
+                        </goals>
+                    </execution>
+
+                    <execution>
+                        <id>kover-html</id>
+                        <goals>
+                            <goal>report-html</goal>
+                        </goals>
+                    </execution>
+
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+        </plugins>
+
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit5</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/kover-maven-plugin/src/functionalTest/templates/tests/kotlin-empty-config/src/main/kotlin/Main.kt
+++ b/kover-maven-plugin/src/functionalTest/templates/tests/kotlin-empty-config/src/main/kotlin/Main.kt
@@ -1,0 +1,11 @@
+package kotlinx.kover.maven.plugin.testing
+
+class Main {
+    fun used() {
+        println("used")
+    }
+
+    fun unused() {
+        println("unused")
+    }
+}

--- a/kover-maven-plugin/src/functionalTest/templates/tests/kotlin-empty-config/src/test/kotlin/MainKtTest.kt
+++ b/kover-maven-plugin/src/functionalTest/templates/tests/kotlin-empty-config/src/test/kotlin/MainKtTest.kt
@@ -1,0 +1,10 @@
+package kotlinx.kover.maven.plugin.testing
+
+import kotlin.test.Test
+
+class MainKtTest {
+    @Test
+    fun myTest() {
+        Main().used()
+    }
+}

--- a/kover-maven-plugin/src/main/kotlin/kotlinx/kover/maven/plugin/mojo/abstracts/AbstractCoverageTaskMojo.kt
+++ b/kover-maven-plugin/src/main/kotlin/kotlinx/kover/maven/plugin/mojo/abstracts/AbstractCoverageTaskMojo.kt
@@ -226,7 +226,9 @@ abstract class AbstractCoverageTaskMojo : AbstractKoverMojo() {
                 .filter { "compile" in it.goals }
                 .filter { execution -> execution.configuration != null && execution.configuration is Xpp3Dom }
                 .flatMap { execution ->
-                    (execution.configuration as Xpp3Dom).getChild("sourceDirs").children.map { toAbsoluteFile(it.value) }
+                    val config = execution.configuration as Xpp3Dom
+                    val sourceDirs = config.getChild("sourceDirs") ?: return@flatMap emptyList()
+                    sourceDirs.children.map { toAbsoluteFile(it.value) }
                 }
         } catch (e: Exception) {
             // in future versions configuration may be changed


### PR DESCRIPTION
When a configuration is specified in the execution for the `compile` target, but the `sourceDirs` child element is missing, an error occurred. A check has been added to fix the error.

Fixes #701