### PR TITLE
Fixed Gradle 9.0 migration issue

### DIFF
--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/CompatibilityTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/CompatibilityTests.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2025 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.kover.gradle.plugin.test.functional.cases
+
+import kotlinx.kover.gradle.plugin.test.functional.framework.configurator.BuildConfigurator
+import kotlinx.kover.gradle.plugin.test.functional.framework.starter.GeneratedTest
+import kotlin.test.assertFalse
+
+internal class CompatibilityTests {
+
+    @GeneratedTest
+    fun BuildConfigurator.testGradle9Compatibility() {
+        addProjectWithKover {
+            sourcesFrom("simple")
+        }
+
+        run("test") {
+            assertFalse(output.contains("Deprecated Gradle features were used in this build"), "There should be no deprecated Gradle features")
+        }
+
+    }
+}

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/aggregation/settings/KoverSettingsGradlePlugin.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/aggregation/settings/KoverSettingsGradlePlugin.kt
@@ -52,9 +52,6 @@ public class KoverSettingsGradlePlugin: Plugin<Settings> {
 
             val agentDependency = configurations.create(SettingsNames.DEPENDENCY_AGENT) {
                 asDependency()
-                attributes {
-                    attribute(Usage.USAGE_ATTRIBUTE, objects.named(KoverUsageAttr.VALUE))
-                }
             }
             dependencies.add(agentDependency.name, rootProject)
 
@@ -78,9 +75,6 @@ public class KoverSettingsGradlePlugin: Plugin<Settings> {
 
         val dependencyConfig = configurations.create(KOVER_DEPENDENCY_NAME) {
             asDependency()
-            attributes {
-                attribute(Usage.USAGE_ATTRIBUTE, objects.named(KoverUsageAttr.VALUE))
-            }
         }
 
         val eachProjectRules = mutableMapOf<String, List<ProjectVerificationRuleSettingsImpl>>()

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/PrepareKover.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/PrepareKover.kt
@@ -23,9 +23,6 @@ import org.gradle.kotlin.dsl.register
 internal fun prepare(project: Project): KoverContext {
     val koverBucketConfiguration = project.configurations.create(KOVER_DEPENDENCY_NAME) {
         asBucket()
-        attributes {
-            attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(KoverUsageAttr.VALUE))
-        }
     }
 
     // Project always consumes its own artifacts


### PR DESCRIPTION
`attributes` block shouldn't be used in dependency configurations

Fixes #716