### PR TITLE
Disabled caching for KoverAgentJarTask

### DIFF
--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/services/KoverAgentJarTask.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/tasks/services/KoverAgentJarTask.kt
@@ -4,22 +4,23 @@
 
 package kotlinx.kover.gradle.plugin.tasks.services
 
-import kotlinx.kover.gradle.plugin.dsl.*
-import kotlinx.kover.gradle.plugin.tools.*
+import kotlinx.kover.gradle.plugin.tools.CoverageTool
+import kotlinx.kover.gradle.plugin.tools.CoverageToolVariant
 import org.gradle.api.DefaultTask
-import org.gradle.api.artifacts.*
-import org.gradle.api.file.*
+import org.gradle.api.file.ArchiveOperations
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
-import org.gradle.kotlin.dsl.support.*
-import javax.inject.*
+import org.gradle.work.DisableCachingByDefault
+import javax.inject.Inject
 
 /**
  * Task to get online instrumentation agent jar file by specified coverage tool.
  *
  * The task is cached, so in general there should not be a performance issue on large projects.
  */
-@CacheableTask
+@DisableCachingByDefault(because = "Local file operations are faster then using build cache")
 internal abstract class KoverAgentJarTask : DefaultTask() {
     // relative sensitivity for file collections which are not FileTree is a comparison by file name and its contents
     @get:InputFiles


### PR DESCRIPTION
There are two cases where this task works:
- for the Kover tool it just copies the jar file from dependencies to the build directory
- for the JaCoCo tool it unzips the file from dependency and copies its content to the build directory

For both these cases using build cache is uneffective, since local copying and uzipping are fast itself. But using build cache inflates it, and it runs slower because the build cache performs some number of additional calculations and archiving.

Fixes #748