### PR TITLE
Fixed support of KSP plugin

### DIFF
--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/AndroidKspTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/AndroidKspTests.kt
@@ -1,0 +1,11 @@
+package kotlinx.kover.gradle.plugin.test.functional.cases
+
+import kotlinx.kover.gradle.plugin.test.functional.framework.checker.CheckerContext
+import kotlinx.kover.gradle.plugin.test.functional.framework.starter.TemplateTest
+
+internal class AndroidKspTests {
+    @TemplateTest("android-ksp", ["koverXmlReport"])
+    fun CheckerContext.testUnitTestsAreDisabledInAgp() {
+
+    }
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-ksp/build.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-ksp/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+	id("com.android.library") version "8.13.0"
+	id("org.jetbrains.kotlin.android") version "2.2.20"
+	id("com.google.devtools.ksp") version "2.2.20-2.0.4"
+	id("org.jetbrains.kotlinx.kover") version "0.9.3-SNAPSHOT"
+}
+
+android {
+	namespace = "com.example.lib"
+	compileSdk = 36
+	defaultConfig.minSdk = 24
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/builds/android-ksp/settings.gradle.kts
+++ b/kover-gradle-plugin/src/functionalTest/templates/builds/android-ksp/settings.gradle.kts
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/artifacts/AbstractVariantArtifacts.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/artifacts/AbstractVariantArtifacts.kt
@@ -90,12 +90,12 @@ internal sealed class AbstractVariantArtifacts(
 
         // local files and compile tasks
         val kotlinCompileTasks = compilations.map { compilation -> compilation.mapNotNull { it.kotlin.compileTask } }
-        val kotlinOutputs = compilations.map { compilation -> compilation.flatMap { it.kotlin.outputs } }
+        val kotlinOutputs = compilations.map { compilation -> compilation.map { it.kotlin.outputs } }
 
         val javaCompileTasks =
             compilations.map { compilation -> if (variantConfig.sources.excludeJava.get()) emptyList() else compilation.mapNotNull { it.java.compileTask } }
         val javaOutputs =
-            compilations.map { compilation -> if (variantConfig.sources.excludeJava.get()) emptyList() else compilation.flatMap { it.java.outputs } }
+            compilations.map { compilation -> if (variantConfig.sources.excludeJava.get()) emptyList() else compilation.map { it.java.outputs } }
 
 
         val sources = compilations.map { unit -> unit.flatMap { it.sources } }

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/origin/VariantOrigin.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/origin/VariantOrigin.kt
@@ -6,6 +6,7 @@ package kotlinx.kover.gradle.plugin.appliers.origin
 
 import kotlinx.kover.gradle.plugin.commons.AndroidBuildVariant
 import org.gradle.api.Task
+import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskCollection
 import org.gradle.api.tasks.testing.Test
@@ -53,7 +54,7 @@ internal class LanguageCompilation(
     /**
      * Directories with compiled classes, outputs of [compileTasks].
      */
-    val outputs: Set<File>,
+    val outputs: FileCollection,
 
     /**
      * In case when no one compile tasks will be triggered,

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/locators/Jvm.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/locators/Jvm.kt
@@ -29,13 +29,13 @@ private fun extractJvmCompilation(
         it["kotlin"].valueCollection("srcDirs")
     }.toSet()
 
-    val kotlinOutputs = compilation["output"].value<ConfigurableFileCollection>("classesDirs").files.filterNot<File> {
-        isJavaOutput(it)
-    }.toSet()
+    val kotlinOutputs = compilation["output"]
+        .value<ConfigurableFileCollection>("classesDirs")
+        .filter { file -> !isJavaOutput(file) }
 
-    val javaOutputs = compilation["output"].value<ConfigurableFileCollection>("classesDirs").files.filter<File> {
-        isJavaOutput(it)
-    }.toSet()
+    val javaOutputs = compilation["output"]
+        .value<ConfigurableFileCollection>("classesDirs")
+        .filter { file -> isJavaOutput(file) }
 
     val kotlinCompileTask = compilation.value<Task>("compileKotlinTask")
     val javaCompileTask = compilation.valueOrNull<TaskProvider<Task>?>("compileJavaTaskProvider")?.orNull

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/locators/KotlinMultiPlatformLocator.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/locators/KotlinMultiPlatformLocator.kt
@@ -124,7 +124,7 @@ private fun DynamicBean.extractKmpAndroidLibraryVariant(): Map<String, Compilati
                 it["kotlin"].valueCollection("srcDirs")
             }.toSet()
 
-            val kotlinOutputs = compilation["output"].value<ConfigurableFileCollection>("classesDirs").files.toSet()
+            val kotlinOutputs = compilation["output"].value<ConfigurableFileCollection>("classesDirs")
             val kotlinCompileTask = compilation.valueOrNull<TaskProvider<Task>?>("compileTaskProvider")?.orNull
             val kotlin = LanguageCompilation(kotlinOutputs, kotlinCompileTask)
             // at the moment, there is no way to get a task and directives for javac from the compilation


### PR DESCRIPTION
The compiler output reading was removed at the Gradle configuration stage, which caused the ConcurrentModificationException, because after reading the directories with Kover, they were modified by KSP

Fixes #766