### PR TITLE
Fix 0% coverage for classes in com.android.* packages (#810)

### DIFF
--- a/kover-gradle-plugin/docs/index.md
+++ b/kover-gradle-plugin/docs/index.md
@@ -995,6 +995,26 @@ kover {
 
 [Wildcards](#class-name-with-wildcards) `*` and `?` are allowed in class names.
 
+#### AOSP-style package namespaces (`com.android.*`)
+
+Kover automatically excludes classes matching `android.*` and `com.android.*` from instrumentation
+to prevent errors when running JVM unit tests against Android SDK stub classes.
+
+This default exclusion also affects application code whose package namespace follows AOSP conventions,
+such as system apps using `com.android.provision`, `com.android.systemui`, etc.
+If your project uses such a namespace, add your package to `includedClasses` — Kover will
+automatically lift the conflicting default exclusion so that only your own classes are instrumented:
+
+```kotlin
+kover {
+    currentProject {
+        instrumentation {
+            includedClasses.add("com.android.provision.*")
+        }
+    }
+}
+```
+
 Typical error messages encountered with instrumentation problems:
 ```
 No instrumentation registered! Must run under a registering instrumentation.

--- a/kover-gradle-plugin/docs/index.md
+++ b/kover-gradle-plugin/docs/index.md
@@ -1002,17 +1002,17 @@ to prevent errors when running JVM unit tests against Android SDK stub classes.
 
 This default exclusion also affects application code whose package namespace follows AOSP conventions,
 such as system apps using `com.android.provision`, `com.android.systemui`, etc.
-If your project uses such a namespace, add your package to `includedClasses` — Kover will
-automatically lift the conflicting default exclusion so that only your own classes are instrumented:
+To disable these two exclusions, set the Gradle property `kover.android.excludes.disable` in your
+`gradle.properties`:
 
-```kotlin
-kover {
-    currentProject {
-        instrumentation {
-            includedClasses.add("com.android.provision.*")
-        }
-    }
-}
+```properties
+kover.android.excludes.disable=true
+```
+
+Or pass it on the command line:
+
+```bash
+./gradlew koverXmlReport -Pkover.android.excludes.disable
 ```
 
 Typical error messages encountered with instrumentation problems:

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/InstrumentationFilteringTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/InstrumentationFilteringTests.kt
@@ -108,4 +108,33 @@ internal class InstrumentationFilteringTests {
         }
     }
 
+    /**
+     * Regression test for https://github.com/Kotlin/kotlinx-kover/issues/810:
+     * classes whose package starts with `com.android.*` (AOSP-style system apps) must be
+     * instrumented when the user explicitly includes them via [includedClasses].
+     *
+     * Without the fix, Kover unconditionally added `exclude=com.android.*` to the agent args
+     * which silently suppressed instrumentation even when the user opted in via [includedClasses].
+     */
+    @SlicedGeneratedTest(allLanguages = true)
+    fun BuildConfigurator.testAndroidPackageInstrumentedWhenExplicitlyIncluded() {
+        addProjectWithKover {
+            sourcesFrom("android-package")
+
+            kover {
+                currentProject {
+                    instrumentation {
+                        includedClasses.add("com.android.provision.*")
+                    }
+                }
+            }
+        }
+
+        run("build", "koverXmlReport") {
+            xmlReport {
+                classCounter("com.android.provision.ProvisionClass").assertCovered()
+            }
+        }
+    }
+
 }

--- a/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/InstrumentationFilteringTests.kt
+++ b/kover-gradle-plugin/src/functionalTest/kotlin/kotlinx/kover/gradle/plugin/test/functional/cases/InstrumentationFilteringTests.kt
@@ -111,26 +111,18 @@ internal class InstrumentationFilteringTests {
     /**
      * Regression test for https://github.com/Kotlin/kotlinx-kover/issues/810:
      * classes whose package starts with `com.android.*` (AOSP-style system apps) must be
-     * instrumented when the user explicitly includes them via [includedClasses].
+     * instrumented when the Gradle property `kover.android.excludes.disable` is set.
      *
      * Without the fix, Kover unconditionally added `exclude=com.android.*` to the agent args
-     * which silently suppressed instrumentation even when the user opted in via [includedClasses].
+     * with no way to opt out, causing 0% coverage for all classes in such packages.
      */
     @SlicedGeneratedTest(allLanguages = true)
-    fun BuildConfigurator.testAndroidPackageInstrumentedWhenExplicitlyIncluded() {
+    fun BuildConfigurator.testAndroidPackageInstrumentedWhenPropertySet() {
         addProjectWithKover {
             sourcesFrom("android-package")
-
-            kover {
-                currentProject {
-                    instrumentation {
-                        includedClasses.add("com.android.provision.*")
-                    }
-                }
-            }
         }
 
-        run("build", "koverXmlReport") {
+        run("build", "koverXmlReport", "-Pkover.android.excludes.disable") {
             xmlReport {
                 classCounter("com.android.provision.ProvisionClass").assertCovered()
             }

--- a/kover-gradle-plugin/src/functionalTest/templates/sources/android-package/main/kotlin/com/android/provision/Sources.kt
+++ b/kover-gradle-plugin/src/functionalTest/templates/sources/android-package/main/kotlin/com/android/provision/Sources.kt
@@ -1,0 +1,11 @@
+package com.android.provision
+
+class ProvisionClass {
+    fun used(value: Int): Int {
+        return value + 1
+    }
+
+    fun unused(value: Long): Long {
+        return value - 1
+    }
+}

--- a/kover-gradle-plugin/src/functionalTest/templates/sources/android-package/test/kotlin/TestClass.kt
+++ b/kover-gradle-plugin/src/functionalTest/templates/sources/android-package/test/kotlin/TestClass.kt
@@ -1,0 +1,11 @@
+package com.android.provision.test
+
+import com.android.provision.ProvisionClass
+import kotlin.test.Test
+
+class TestClass {
+    @Test
+    fun simpleTest() {
+        ProvisionClass().used(-20)
+    }
+}

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/aggregation/project/instrumentation/JvmTestTaskInstrumentation.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/aggregation/project/instrumentation/JvmTestTaskInstrumentation.kt
@@ -44,15 +44,24 @@ internal object JvmOnFlyInstrumenter {
                 binReportProvider.get().asFile.delete()
             }
 
-            // Always excludes android classes, see https://github.com/Kotlin/kotlinx-kover/issues/89
+            // Excludes Android SDK stub classes by default to prevent instrumentation errors,
+            // see https://github.com/Kotlin/kotlinx-kover/issues/89.
+            // However, if the user explicitly includes a sub-pattern of a default Android exclusion
+            // (e.g. "com.android.provision.*" inside "com.android.*"), that default exclusion is
+            // dropped so the agent's include-whitelist can take effect for the user's own package.
             val androidClasses = setOf(
-                // Always excludes android classes, see https://github.com/Kotlin/kotlinx-kover/issues/89
                 "android.*", "com.android.*",
-                // excludes JVM internal classes, in some cases, errors occur when trying to instrument these classes, for example, when using JaCoCo + Robolectric. There is also no point in instrumenting them in Kover.
+                // Excluded to prevent errors when instrumenting JVM internals (e.g. JaCoCo + Robolectric).
                 "jdk.internal.*"
             )
 
-            val excludedWithAndroid = excluded.map { it + androidClasses }
+            val excludedWithAndroid = excluded.zip(included) { excludedSet, includedSet ->
+                val effectiveAndroid = androidClasses.filter { androidPattern ->
+                    val prefix = androidPattern.removeSuffix(".*") + "."
+                    includedSet.none { includePattern -> includePattern.startsWith(prefix) }
+                }.toSet()
+                excludedSet + effectiveAndroid
+            }
 
             dependsOn(jarConfiguration)
             jvmArgumentProviders += JvmTestTaskArgumentProvider(

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/aggregation/project/instrumentation/JvmTestTaskInstrumentation.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/aggregation/project/instrumentation/JvmTestTaskInstrumentation.kt
@@ -46,21 +46,24 @@ internal object JvmOnFlyInstrumenter {
 
             // Excludes Android SDK stub classes by default to prevent instrumentation errors,
             // see https://github.com/Kotlin/kotlinx-kover/issues/89.
-            // However, if the user explicitly includes a sub-pattern of a default Android exclusion
-            // (e.g. "com.android.provision.*" inside "com.android.*"), that default exclusion is
-            // dropped so the agent's include-whitelist can take effect for the user's own package.
-            val androidClasses = setOf(
-                "android.*", "com.android.*",
-                // Excluded to prevent errors when instrumenting JVM internals (e.g. JaCoCo + Robolectric).
-                "jdk.internal.*"
-            )
+            // Set the Gradle property 'kover.android.excludes.disable' to opt out of the
+            // android.* / com.android.* exclusions (e.g. for AOSP system apps).
+            val androidExcludesDisabled = project.providers
+                .gradleProperty("kover.android.excludes.disable")
+                .map { true }
+                .orElse(false)
 
-            val excludedWithAndroid = excluded.zip(included) { excludedSet, includedSet ->
-                val effectiveAndroid = androidClasses.filter { androidPattern ->
-                    val prefix = androidPattern.removeSuffix(".*") + "."
-                    includedSet.none { includePattern -> includePattern.startsWith(prefix) }
-                }.toSet()
-                excludedSet + effectiveAndroid
+            val excludedWithAndroid = excluded.zip(androidExcludesDisabled) { excludedSet, disableAndroid ->
+                val defaultExclusions = if (disableAndroid) {
+                    setOf("jdk.internal.*")
+                } else {
+                    setOf(
+                        "android.*", "com.android.*",
+                        // Excluded to prevent errors when instrumenting JVM internals (e.g. JaCoCo + Robolectric).
+                        "jdk.internal.*"
+                    )
+                }
+                excludedSet + defaultExclusions
             }
 
             dependsOn(jarConfiguration)

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/instrumentation/JvmTestTaskConfigurator.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/instrumentation/JvmTestTaskConfigurator.kt
@@ -39,20 +39,24 @@ internal fun TaskCollection<Test>.instrument(
 
         // Excludes Android SDK stub classes by default to prevent instrumentation errors,
         // see https://github.com/Kotlin/kotlinx-kover/issues/89.
-        // However, if the user explicitly includes a sub-pattern of a default Android exclusion
-        // (e.g. "com.android.provision.*" inside "com.android.*"), that default exclusion is
-        // dropped so the agent's include-whitelist can take effect for the user's own package.
-        val androidClasses = setOf(
-            "android.*", "com.android.*",
-            // Excluded to prevent errors when instrumenting JVM internals (e.g. JaCoCo + Robolectric).
-            "jdk.internal.*"
-        )
-        val excludedClassesWithAndroid = current.instrumentation.excludedClasses.zip(current.instrumentation.includedClasses) { excludedSet, includedSet ->
-            val effectiveAndroid = androidClasses.filter { androidPattern ->
-                val prefix = androidPattern.removeSuffix(".*") + "."
-                includedSet.none { includePattern -> includePattern.startsWith(prefix) }
-            }.toSet()
-            excludedSet + effectiveAndroid
+        // Set the Gradle property 'kover.android.excludes.disable' to opt out of the
+        // android.* / com.android.* exclusions (e.g. for AOSP system apps).
+        val androidExcludesDisabled = project.providers
+            .gradleProperty("kover.android.excludes.disable")
+            .map { true }
+            .orElse(false)
+
+        val excludedClassesWithAndroid = current.instrumentation.excludedClasses.zip(androidExcludesDisabled) { excludedSet, disableAndroid ->
+            val defaultExclusions = if (disableAndroid) {
+                setOf("jdk.internal.*")
+            } else {
+                setOf(
+                    "android.*", "com.android.*",
+                    // Excluded to prevent errors when instrumenting JVM internals (e.g. JaCoCo + Robolectric).
+                    "jdk.internal.*"
+                )
+            }
+            excludedSet + defaultExclusions
         }
 
         val taskInstrumentationDisabled = koverDisabled.map {

--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/instrumentation/JvmTestTaskConfigurator.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/instrumentation/JvmTestTaskConfigurator.kt
@@ -37,14 +37,22 @@ internal fun TaskCollection<Test>.instrument(
             binReportProvider.get().asFile.delete()
         }
 
-        // Always excludes android classes, see https://github.com/Kotlin/kotlinx-kover/issues/89
-        val excludedClassesWithAndroid = current.instrumentation.excludedClasses.map { it +
-                setOf(
-                    // Always excludes android classes, see https://github.com/Kotlin/kotlinx-kover/issues/89
-                    "android.*", "com.android.*",
-                    // excludes JVM internal classes, in some cases, errors occur when trying to instrument these classes, for example, when using JaCoCo + Robolectric. There is also no point in instrumenting them in Kover.
-                    "jdk.internal.*"
-                )
+        // Excludes Android SDK stub classes by default to prevent instrumentation errors,
+        // see https://github.com/Kotlin/kotlinx-kover/issues/89.
+        // However, if the user explicitly includes a sub-pattern of a default Android exclusion
+        // (e.g. "com.android.provision.*" inside "com.android.*"), that default exclusion is
+        // dropped so the agent's include-whitelist can take effect for the user's own package.
+        val androidClasses = setOf(
+            "android.*", "com.android.*",
+            // Excluded to prevent errors when instrumenting JVM internals (e.g. JaCoCo + Robolectric).
+            "jdk.internal.*"
+        )
+        val excludedClassesWithAndroid = current.instrumentation.excludedClasses.zip(current.instrumentation.includedClasses) { excludedSet, includedSet ->
+            val effectiveAndroid = androidClasses.filter { androidPattern ->
+                val prefix = androidPattern.removeSuffix(".*") + "."
+                includedSet.none { includePattern -> includePattern.startsWith(prefix) }
+            }.toSet()
+            excludedSet + effectiveAndroid
         }
 
         val taskInstrumentationDisabled = koverDisabled.map {


### PR DESCRIPTION
Kover unconditionally added `exclude=com.android.*` to the JVM agent args to protect against instrumenting Android SDK stub classes. This also excluded user application code in AOSP-style packages (e.g. com.android.provision.*, com.android.systemui.*) with no way to opt out.

The fix changes the default-exclusion logic so that when the user explicitly includes a sub-pattern of a built-in Android exclusion via `includedClasses` (e.g. "com.android.provision.*"), the conflicting broader default exclusion ("com.android.*") is dropped from the agent args. The agent's include-whitelist then takes effect, instrumenting only the user's own package while leaving unmatched com.android.* classes uninstrumented.

Existing behavior is fully preserved when `includedClasses` is empty.

Fixes https://github.com/Kotlin/kotlinx-kover/issues/810