### PR TITLE
Fix Gradle 10 deprecation: replace Project object with project() depe…

### DIFF
--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/PrepareKover.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/appliers/PrepareKover.kt
@@ -26,7 +26,7 @@ internal fun prepare(project: Project): KoverContext {
     }
 
     // Project always consumes its own artifacts
-    project.dependencies.add(KOVER_DEPENDENCY_NAME, project)
+    project.dependencies.add(KOVER_DEPENDENCY_NAME, project.dependencies.project(mapOf("path" to project.path)))
 
     val projectExtension = project.extensions.create<KoverProjectExtensionImpl>(
         KOVER_PROJECT_EXTENSION_NAME,


### PR DESCRIPTION
…ndency notation

In PrepareKover.kt, the project itself was added as a dependency using the Project object directly:

    project.dependencies.add(KOVER_DEPENDENCY_NAME, project)

Starting with Gradle 9.6-RC1, this triggers a deprecation warning:

    Using a Project object as a dependency notation has been deprecated.
    This will fail with an error in Gradle 10.
    Please use the project(String) method on DependencyHandler or the
    createProjectDependency(String) method on DependencyFactory instead.

Full stack trace:

    at o.g.a.i.notations.DependencyProjectNotationConverter.convert(DependencyProjectNotationConverter.java:48)
    at o.g.a.i.notations.DependencyProjectNotationConverter.convert(DependencyProjectNotationConverter.java:29)
    at o.g.i.typeconversion.TypeFilteringNotationConverter.convert(TypeFilteringNotationConverter.java:33)
    at o.g.i.typeconversion.CompositeNotationConverter.convert(CompositeNotationConverter.java:34)
    at o.g.i.typeconversion.NotationConverterToNotationParserAdapter.parseNotation(NotationConverterToNotationParserAdapter.java:31)
    at o.g.i.typeconversion.ErrorHandlingNotationParser.parseNotation(ErrorHandlingNotationParser.java:48)
    at o.g.a.i.artifacts.DefaultDependencyFactory.createDependency(DefaultDependencyFactory.java:77)
    at o.g.a.i.artifacts.dsl.dependencies.DefaultDependencyHandler.create(DefaultDependencyHandler.java:166)
    at o.g.a.i.artifacts.dsl.dependencies.DefaultDependencyHandler.doAddRegularDependency(DefaultDependencyHandler.java:195)
    at o.g.a.i.artifacts.dsl.dependencies.DefaultDependencyHandler.doAdd(DefaultDependencyHandler.java:190)
    at o.g.a.i.artifacts.dsl.dependencies.DefaultDependencyHandler.add(DefaultDependencyHandler.java:118)
    at o.g.a.i.artifacts.dsl.dependencies.DefaultDependencyHandler.add(DefaultDependencyHandler.java:112)
    at kotlinx.kover.gradle.plugin.appliers.PrepareKoverKt.prepare(PrepareKover.kt:29)
    at kotlinx.kover.gradle.plugin.KoverGradlePlugin.apply(KoverGradlePlugin.kt:29)
    at kotlinx.kover.gradle.plugin.KoverGradlePlugin.apply(KoverGradlePlugin.kt:21)

Fix: use project.dependencies.project(mapOf("path" to project.path)) which is the recommended API and consistent with the settings plugin (KoverSettingsGradlePlugin.kt) that already uses project(descriptor.path).

Fixes #813 

Environment:
- Kover: 0.9.8
- Gradle: 9.6.0-RC1
- Kotlin: 2.4.0-RC2