### PR TITLE
Fix AGP 9 built-in Kotlin projects routed into the pre-9 variant path

### DIFF
--- a/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/locators/KotlinAndroidLocator.kt
+++ b/kover-gradle-plugin/src/main/kotlin/kotlinx/kover/gradle/plugin/locators/KotlinAndroidLocator.kt
@@ -7,6 +7,7 @@ package kotlinx.kover.gradle.plugin.locators
 import kotlinx.kover.gradle.plugin.appliers.origin.AllVariantOrigins
 import kotlinx.kover.gradle.plugin.commons.KoverCriticalException
 import kotlinx.kover.gradle.plugin.commons.androidMajorVersion
+import kotlinx.kover.gradle.plugin.commons.hasAndroid9WithKotlin
 import kotlinx.kover.gradle.plugin.util.bean
 import org.gradle.api.Project
 
@@ -25,7 +26,9 @@ internal fun Project.locateKotlinAndroidVariants(variants: List<AndroidVariantIn
     val kotlinTarget = kotlinExtension["target"]
 
     val majorVersion = project.extensions.androidMajorVersion()
-    val origins = if (majorVersion < 9) {
+    // Built-in Kotlin implies AGP 9+, even when androidMajorVersion() can't read the version (#815).
+    val isAgp9OrNewer = majorVersion >= 9 || project.hasAndroid9WithKotlin()
+    val origins = if (!isAgp9OrNewer) {
         project.androidVariantsBefore9(androidExtension, kotlinTarget)
     } else {
         project.androidVariants(androidExtension, variants, kotlinTarget)


### PR DESCRIPTION
## Summary

Fixes #815.

`locateKotlinAndroidVariants()` picks the variant-extraction path based on `androidMajorVersion()`:

```kotlin
val majorVersion = project.extensions.androidMajorVersion()
val origins = if (majorVersion < 9) {
    project.androidVariantsBefore9(androidExtension, kotlinTarget)  // reads applicationVariants
} else {
    project.androidVariants(androidExtension, variants, kotlinTarget)
}
```

`androidMajorVersion()` reflectively reads `androidComponents.pluginVersion.major` and falls back to `0` when the read returns null, so it can only return the real major or `0` — never an intermediate value:

```kotlin
internal fun ExtensionContainer.androidMajorVersion(): Int {
    val androidComponents = findByName("androidComponents")?.bean() ?: return 0
    return androidComponents.beanOrNull("pluginVersion")?.valueOrNull<Int>("major") ?: 0
}
```

When that read falls back to `0` on an AGP 9 project, `0 < 9` routes into `androidVariantsBefore9()`, which reads the `applicationVariants` property removed in AGP 9 and fails configuration:

```
Could not get unknown property 'applicationVariants' for object of type
com.android.build.gradle.internal.dsl.ApplicationExtensionImpl$AgpDecorated
```

We hit this intermittently on CI on a `com.android.application` module using AGP's built-in Kotlin — only under the configuration cache and not on every run, which points at the reflective `pluginVersion` read returning null at the moment the locator runs.

**Why not a capability check on `applicationVariants`:** branching on whether the `android` extension still exposes `applicationVariants`/`libraryVariants` isn't reliable. The failing build proves `hasProperty("applicationVariants")` returns `true` on the AGP 9 `AgpDecorated` extension (the error is raised by the subsequent `getProperty`, only reached after `"applicationVariants" in androidExtension` passes), so `hasProperty` can't detect the removed API.

**Fix:** a project using AGP's built-in Kotlin — no `kotlin-android` plugin but a `kotlin` extension, i.e. `hasAndroid9WithKotlin()` — is necessarily AGP 9+, since built-in Kotlin was introduced in AGP 9. Treat that as AGP 9+ regardless of the version read:

```kotlin
val isAgp9OrNewer = majorVersion >= 9 || project.hasAndroid9WithKotlin()
val origins = if (!isAgp9OrNewer) { ... }
```

This drops the dependency on the fragile `pluginVersion` read for the built-in-Kotlin case (the one reaching this locator via the `hasAndroid9WithKotlin()` branch in `ProvidedVariantsLocator`), and is a no-op when the version read works or for AGP 7/8 projects using the `kotlin-android` plugin.

## Verification

I could not run the full Gradle build locally — the `build-logic` build needs a JDK 8 toolchain I don't have provisioned; `:kover-gradle-plugin:compileKotlin` otherwise picks up the change. Relying on CI for the full build. Happy to add a functional test if you can point me at the AGP 9 test fixture setup — the trigger is timing-dependent, so I'd appreciate guidance on simulating the `0` fallback deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)